### PR TITLE
Add GitHub CI Build and SonarCloud Analysis

### DIFF
--- a/.github/workflows/android-sonarcloud.yml
+++ b/.github/workflows/android-sonarcloud.yml
@@ -1,0 +1,48 @@
+name: Android Build And SonarCloud Analysis
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+  release:
+    types: [created]
+jobs:
+  build:
+    name: Build and analyze
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: 'zulu' # Alternative distribution options are available
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./android-src/KV4PHT/gradlew
+      - name: Build and analyze
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew build sonar --info
+        working-directory: android-src/KV4PHT
+      - name: Upload APK
+        if: startsWith(github.ref, 'refs/tags')
+        uses: AButler/upload-release-assets@v3.0
+        with:
+          files: "android-src/KV4PHT/app/build/outputs/apk/release/app-release-unsigned.apk"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/aprs/parser/Callsign.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/aprs/parser/Callsign.java
@@ -96,9 +96,10 @@ public class Callsign implements Serializable {
         byte[] ax25 = new byte[7];
 	// shift " " by one
 	java.util.Arrays.fill(ax25, (byte)0x40);
-	if (callbytes.length > 6)
+	if (callbytes.length > 6) {
 		throw new IllegalArgumentException("Callsign " + callsign + " is too long for AX.25!");
-        for (int i = 0; i < callbytes.length; i++) {
+	}
+	for (int i = 0; i < callbytes.length; i++) {
 		ax25[i] = (byte)(callbytes[i] << 1);
 	}
 	int ssidval = 0;

--- a/android-src/KV4PHT/app/src/main/res/layout/activity_settings.xml
+++ b/android-src/KV4PHT/app/src/main/res/layout/activity_settings.xml
@@ -164,7 +164,7 @@
             android:textAllCaps="true"
             android:enabled="true"
             android:onClick="closedCaptionsButtonClicked"
-            android:layout_gravity="right"
+            android:layout_gravity="end"
             android:textAlignment="viewEnd"
             android:padding="0dp" />
 

--- a/android-src/KV4PHT/build.gradle
+++ b/android-src/KV4PHT/build.gradle
@@ -2,4 +2,13 @@
 plugins {
     id 'com.android.application' version '8.3.0' apply false
     id 'com.android.library' version '8.3.0' apply false
+    id "org.sonarqube" version "5.1.0.4882"
+}
+
+sonar {
+  properties {
+    property "sonar.projectKey", "wsciaroni_kv4p-ht"
+    property "sonar.organization", "wsciaroni"
+    property "sonar.host.url", "https://sonarcloud.io"
+  }
 }


### PR DESCRIPTION
Hey Vance,

I appreciate all the work you've done on this project. I want to help this project succeed by contributing where I can. In this case, I have added a CI pipeline that will ensure builds (and quality) on merge requests to your project (as well as within your project). We can create a SonarCloud project that you can manage. The issues will be "blockers" on new code until you mark them as "Accepted" or whatever you wish. This just lets you be in control of any behavior that makes it in.

Unlike a lot of other static analysis tools that I have used, this one really is minimal overhead and tends to catch some things that would have previously caused substantial issues if released. Feel free to let me know what you think of this.

(GitHub Actions are free on public projects so this is low risk financially).


If you like this, we'll want to do the following:

- [ ] Transfer the SonarCloud project over to your ownership
- [ ] Update the `build.gradle` with the new SonarCloud project key after it is moved.
- [ ] Create the GitHub Secret to hold your `SONAR_TOKEN`

73

## Updates

I have squashed the commits, please update your local branch with the following. Be careful, it includes a force reset...

```bash
git fetch
git checkout main
git reset --hard origin/main
```