### PR TITLE
Updates PIO config and README to set what core interrupts run on.

### DIFF
--- a/microcontroller-src/README.md
+++ b/microcontroller-src/README.md
@@ -51,6 +51,10 @@
    - Select version **2.0.17**. The code needs to be updated to support 3.X
    - Click **Install** and Wait for the installation to complete.
 
+3. **Configure**
+   - Go to `Tools` > `Events Run On` > Select `Core 0`
+      - This is done so audio processing interrupts run on a separate thread for maximum stability.
+
 ### Install Required Libraries
 
 1. **Install EspSoftwareSerial:**

--- a/microcontroller-src/platformio.ini
+++ b/microcontroller-src/platformio.ini
@@ -16,6 +16,9 @@ platform = espressif32
 board = esp32dev
 framework = arduino
 monitor_speed = 921600
+build_flags =
+  -DARDUINO_RUNNING_CORE=1
+  -DARDUINO_EVENT_RUNNING_CORE=0
 lib_deps =
     ; fatpat/DRA818@^1.0.1 
     https://github.com/fatpat/arduino-dra818.git#v1.0.1 ; v1.0.1 is the latest release, but has not been pushed to registry. Update later


### PR DESCRIPTION
When I pushed my previous PR I didn't realize that the event processing core needed to be changed. This updates the config to set it, as well as updates the README on how to set it for Arduino.