### PR TITLE
Skip Lint for Android Build Check

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -41,9 +41,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew check --stacktrace
+        run: ./gradlew check -x lint --stacktrace
       - name: 'Gradle Build'
-        run: ./gradlew build
+        run: ./gradlew build -x lint --stacktrace
       - name: Upload APK
         if: startsWith(github.ref, 'refs/tags')
         uses: AButler/upload-release-assets@v3.0


### PR DESCRIPTION
This adds the build command flag to skip the lint on pipeline build.