### PR TITLE
Set the ability to add a memory setting from intent

### DIFF
--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/AddEditMemoryActivity.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/AddEditMemoryActivity.java
@@ -27,6 +27,7 @@ import android.widget.EditText;
 import android.widget.TextView;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.lifecycle.ViewModelProvider;
 
 import com.google.android.material.textfield.TextInputEditText;
 import com.vagell.kv4pht.R;
@@ -122,6 +123,25 @@ public class AddEditMemoryActivity extends AppCompatActivity {
                     AutoCompleteTextView editMemoryGroupTextInputEditText = findViewById(R.id.editMemoryGroupTextInputEditText);
                     editMemoryGroupTextInputEditText.setText(selectedMemoryGroup, false);
                 }
+
+                String offset = extras.getString("offset");
+                if (offset != null) {
+                    AutoCompleteTextView editOffset = findViewById(R.id.editOffsetTextView);
+                    editOffset.setText(offset, false);
+                }
+
+                String tone = extras.getString("tone");
+                if (tone != null) {
+                    AutoCompleteTextView editTone = findViewById(R.id.editToneTextView);
+                    editTone.setText(tone, false);
+                }
+
+                String name = extras.getString("name");
+                if (name != null) {
+                    TextInputEditText editNameTextInputEditText = findViewById(R.id.editNameTextInputEditText);
+                    editNameTextInputEditText.setText(name);
+                }
+
             }
         }
 
@@ -160,6 +180,13 @@ public class AddEditMemoryActivity extends AppCompatActivity {
         threadPoolExecutor.execute(new Runnable() {
             @Override
             public void run() {
+                if( MainViewModel.appDb == null ) {
+                    //For example direct call other app intent.
+                    //If app is not already open do not nullpointer-exception.
+                    MainViewModel preloader = new MainViewModel();
+                    preloader.setActivity(activity);
+                    preloader.loadData();
+                }
                 List<String> memoryGroups = MainViewModel.appDb.channelMemoryDao().getGroups();
 
                 // Remove any blank memory groups from the list (shouldn't have been saved, ideally).


### PR DESCRIPTION
Set the ability to call a memory setting from intent, offset/tone/name included also, prevent nullpointer-exception. See bug #105 

This makes it possible to programmatically bring up the screen with the tone and offset also prefilled. eg:

```
Intent intent = new Intent("com.vagell.kv4pht.ADD_MEMORY_ACTION");
 intent.putExtra("requestCode", REQUEST_ADD_MEMORY);//0
 intent.putExtra("activeFrequencyStr", "146.55");//Only 2M
 intent.putExtra("selectedMemoryGroup", selectedMemoryGroup);
 //new
 intent.putExtra("offset", "Up");
 intent.putExtra("tone", "101.3");
startActivityForResult(intent, REQUEST_ADD_MEMORY);*/
```