### PR TITLE
Attempt to fix low transmit audio level on Samsung phones

### DIFF
--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
@@ -1548,7 +1548,7 @@ public class MainActivity extends AppCompatActivity {
             audioRecord = null;
         }
 
-        audioRecord = new AudioRecord(MediaRecorder.AudioSource.VOICE_COMMUNICATION, RadioAudioService.AUDIO_SAMPLE_RATE, channelConfig,
+        audioRecord = new AudioRecord(MediaRecorder.AudioSource.UNPROCESSED, RadioAudioService.AUDIO_SAMPLE_RATE, channelConfig,
                 audioFormat, minBufferSize);
 
         if (audioRecord.getState() != AudioRecord.STATE_INITIALIZED) {


### PR DESCRIPTION
Samsung handsets exhibit low transmit audio level. This PR attempts to fix this issue.

This is what ChatGPT said about this issue:

**Gain or Processing Differences Across Devices**

-  Problem: Samsung and other manufacturers often include custom audio processing that might reduce the input volume, such as noise suppression or echo cancellation

-  Solution: Try disabling these processing features, if they are not required

The UNPROCESSED option (available in newer Android versions) can bypass any manufacturer-specific processing.