### PR TITLE
Add Protobuf Messages

### DIFF
--- a/bridge/.gitignore
+++ b/bridge/.gitignore
@@ -1,0 +1,1 @@
+autogen/

--- a/bridge/GenerateBridgeSources.py
+++ b/bridge/GenerateBridgeSources.py
@@ -1,0 +1,46 @@
+import os
+import subprocess
+
+def generate_protobuf_code(proto_dir, autogen_dir):
+  """Generates Python, Java, and C++ code from protobuf files.
+
+  Args:
+    proto_dir: The directory containing the .proto files.
+    autogen_dir: The directory to output the generated code.
+  """
+
+  # Create the autogen directory if it doesn't exist
+  os.makedirs(autogen_dir, exist_ok=True)
+
+  # Find all .proto files in the proto directory
+  proto_files = [f for f in os.listdir(proto_dir) if f.endswith(".proto")]
+
+  # Generate code for each .proto file
+  for proto_file in proto_files:
+    proto_path = os.path.join(proto_dir, proto_file)
+
+    # Generate Python code
+    subprocess.run([
+        "protoc",
+        f"--python_out={autogen_dir}",
+        proto_path
+    ])
+
+    # Generate Java code
+    subprocess.run([
+        "protoc",
+        f"--java_out={autogen_dir}",
+        proto_path
+    ])
+
+    # Generate C++ code
+    subprocess.run([
+        "protoc",
+        f"--cpp_out={autogen_dir}",
+        proto_path
+    ])
+
+if __name__ == "__main__":
+  proto_dir = "./protobuf"
+  autogen_dir = "./autogen"
+  generate_protobuf_code(proto_dir, autogen_dir)

--- a/bridge/protobuf/bridge.proto
+++ b/bridge/protobuf/bridge.proto
@@ -1,0 +1,37 @@
+syntax = "proto3";
+
+message AudioCommand {
+ fixed32 bitrate = 1;
+ sfixed64 length = 2;
+}
+
+message SetSquelchCommand {
+  fixed32 level = 1;
+}
+
+message GetSquelchCommand {
+  fixed32 level = 1;
+}
+
+message SetFrequency {
+  fixed32 freq_hz = 1;
+}
+
+message GetFrequency {
+}
+
+message AppToEmbedded {
+  oneof command {
+  	AudioCommand audio = 1;
+  	SetSquelchCommand set_squelch = 2;
+  	GetSquelchCommand get_squelch = 3;
+  	SetFrequency set_frequency = 4;
+  	GetFrequency get_frequency = 5;
+  }
+}
+
+message embeddedToApp {
+    oneof command {
+        AudioCommand audio = 1;
+    }
+}


### PR DESCRIPTION
This adds a script that would be used to serialize the commands to and from the embedded device.

For this to be used we would need to add the probof library as a dependency for the project's builds.

This should allow for a more robust protocol and easy adoption for other projects regardless of language.