### PR TITLE
ADC_ATTEN_DB_12 is only defined in some versions? #198

### DIFF
--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
@@ -124,6 +124,10 @@ int fadeDirection = 0; // 0: no fade, 1: fade in, -1: fade out
 int attenuation = ATTENUATION_MAX; // Full volume
 bool lastSquelched = false;
 
+// 11dB vs 12dB is a ...version thing?
+#ifndef ADC_ATTEN_DB_12
+#define ADC_ATTEN_DB_12 ADC_ATTEN_DB_11
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Forward Declarations


### PR DESCRIPTION
Bug fix. I'm not sure what's causing the difference here, but ADC_ATTEN_DB_11 vs DB_12 I think is just a naming change.  For some reason, my build environment uses DB_11.

Maybe this is an Arduino vs PlatformIO thing.  I use PlatformIO.  But this change is backward compatible.