### PR TITLE
Fix SA818 Module Definition and Improve Squelch Behavior

### DIFF
--- a/.github/workflows/arduino.yml
+++ b/.github/workflows/arduino.yml
@@ -30,5 +30,6 @@ jobs:
           libraries: |
             - name: EspSoftwareSerial
               version: 8.1.0
-            - source-url: https://github.com/fatpat/arduino-dra818.git#89582e3ef7bf3f31f1af149e32cec16c4b9e4cf2
+            - source-url: https://github.com/fatpat/arduino-dra818.git
+              vaersion: 89582e3ef7bf3f31f1af149e32cec16c4b9e4cf2
           verbose: true

--- a/.github/workflows/arduino.yml
+++ b/.github/workflows/arduino.yml
@@ -30,5 +30,5 @@ jobs:
           libraries: |
             - name: EspSoftwareSerial
               version: 8.1.0
-            - source-url: https://github.com/fatpat/arduino-dra818.git@89582e3ef7bf3f31f1af149e32cec16c4b9e4cf2
+            - source-url: https://github.com/fatpat/arduino-dra818.git#89582e3ef7bf3f31f1af149e32cec16c4b9e4cf2
           verbose: true

--- a/.github/workflows/arduino.yml
+++ b/.github/workflows/arduino.yml
@@ -30,5 +30,5 @@ jobs:
           libraries: |
             - name: EspSoftwareSerial
               version: 8.1.0
-            - source-url: https://github.com/fatpat/arduino-dra818.git
+            - source-url: https://github.com/fatpat/arduino-dra818.git@89582e3ef7bf3f31f1af149e32cec16c4b9e4cf2
           verbose: true

--- a/.github/workflows/arduino.yml
+++ b/.github/workflows/arduino.yml
@@ -31,5 +31,5 @@ jobs:
             - name: EspSoftwareSerial
               version: 8.1.0
             - source-url: https://github.com/fatpat/arduino-dra818.git
-              vaersion: 89582e3ef7bf3f31f1af149e32cec16c4b9e4cf2
+              version: 89582e3ef7bf3f31f1af149e32cec16c4b9e4cf2
           verbose: true

--- a/.github/workflows/arduino.yml
+++ b/.github/workflows/arduino.yml
@@ -30,5 +30,5 @@ jobs:
           libraries: |
             - name: EspSoftwareSerial
               version: 8.1.0
-            - source-url: https://github.com/fatpat/arduino-dra818/archive/refs/tags/v1.0.1.zip
+            - source-url: https://github.com/fatpat/arduino-dra818.git
           verbose: true

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
@@ -117,14 +117,6 @@ bool i2sStarted = false;
 #define I2S_ADC_UNIT ADC_UNIT_1
 #define I2S_ADC_CHANNEL ADC1_CHANNEL_6
 
-// Squelch parameters (for graceful fade to silence)
-#define FADE_SAMPLES 256  // Must be a power of two
-#define ATTENUATION_MAX 256
-int fadeCounter    = 0;
-int fadeDirection  = 0;                // 0: no fade, 1: fade in, -1: fade out
-int attenuation    = ATTENUATION_MAX;  // Full volume
-bool lastSquelched = false;
-
 // 11dB vs 12dB is a ...version thing?
 #ifndef ADC_ATTEN_DB_12
 #define ADC_ATTEN_DB_12 ADC_ATTEN_DB_11
@@ -351,9 +343,9 @@ void loop() {
               paramBytesMissing--;
             }
             if (paramsStr.charAt(0) == 'v') {
-              dra = new DRA818(&Serial2, DRA818_VHF);
+              dra = new DRA818(&Serial2, SA818_VHF);
             } else if (paramsStr.charAt(0) == 'u') {
-              dra = new DRA818(&Serial2, DRA818_UHF);
+              dra = new DRA818(&Serial2, SA818_UHF);
             } else {
               // Unexpected.
             }
@@ -606,37 +598,9 @@ void loop() {
 
       bool squelched = (digitalRead(SQ_PIN) == HIGH);
 
-      // Check for squelch status change
-      if (squelched != lastSquelched) {
-        if (squelched) {
-          // Start fade-out
-          fadeCounter   = FADE_SAMPLES;
-          fadeDirection = -1;
-        } else {
-          // Start fade-in
-          fadeCounter   = FADE_SAMPLES;
-          fadeDirection = 1;
-        }
-      }
-      lastSquelched = squelched;
-
-      int attenuationIncrement = ATTENUATION_MAX / FADE_SAMPLES;
-
       for (int i = 0; i < samplesRead; i++) {
-
-        // Adjust attenuation during fade
-        if (fadeCounter > 0) {
-          fadeCounter--;
-          attenuation += fadeDirection * attenuationIncrement;
-          attenuation = max(0, min(attenuation, ATTENUATION_MAX));
-        } else {
-          attenuation   = squelched ? 0 : ATTENUATION_MAX;
-          fadeDirection = 0;
-        }
-
-        // Apply attenuation to the sample
-        int16_t sample = (int32_t)remove_dc(((2048 - (buffer16[i] & 0xfff)) << 4)) * attenuation >> 8;
-        buffer8[i]     = (sample >> 8);  // Signed
+        int16_t sample = remove_dc(2048 - (int16_t)(buffer16[i] & 0xfff));
+        buffer8[i]     = squelched ? 0 : (sample >> 4);  // Signed
       }
 
       Serial.write(buffer8, samplesRead);

--- a/microcontroller-src/platformio.ini
+++ b/microcontroller-src/platformio.ini
@@ -21,5 +21,5 @@ build_flags =
   -DARDUINO_EVENT_RUNNING_CORE=0
 lib_deps =
     ; fatpat/DRA818@^1.0.1 
-    https://github.com/fatpat/arduino-dra818.git#v1.0.1 ; v1.0.1 is the latest release, but has not been pushed to registry. Update later
+    https://github.com/fatpat/arduino-dra818.git
     plerup/EspSoftwareSerial@^8.2.0

--- a/microcontroller-src/platformio.ini
+++ b/microcontroller-src/platformio.ini
@@ -21,5 +21,5 @@ build_flags =
   -DARDUINO_EVENT_RUNNING_CORE=0
 lib_deps =
     ; fatpat/DRA818@^1.0.1 
-    https://github.com/fatpat/arduino-dra818.git
+    https://github.com/fatpat/arduino-dra818.git#89582e3ef7bf3f31f1af149e32cec16c4b9e4cf2
     plerup/EspSoftwareSerial@^8.2.0


### PR DESCRIPTION

### Summary  
This PR corrects the module definition and removes redundant code related to squelch (SQ) fade-in/fade-out, which was causing an unintended **loud pop** on startup.  

### Changes  
1. **Module Correction:**  
   - Updated the module reference from `DRA818` to `SA818` to accurately reflect the hardware in use.  

2. **SQ Fade-in/Fade-out Fix:**  
   - Removed redundant logic related to SQ fade-in/fade-out, which was not needed and introduced unintended behavior.  
   - This eliminates a **loud pop/bang** occurring immediately after a cold start.  

