### PR TITLE
Improve Handshake Process with HELLO Message

### DIFF
--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
@@ -1035,7 +1035,7 @@ public class RadioAudioService extends Service {
                 callbacks.missingFirmware();
                 setMode(MODE_BAD_FIRMWARE);
             }
-        }, 30000);
+        }, 60000);
     }
 
     private void initAfterESP32Connected() {

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
@@ -979,7 +979,7 @@ public class RadioAudioService extends Service {
                 callbacks.missingFirmware();
                 setMode(MODE_BAD_FIRMWARE);
             }
-        }, 500);
+        }, 1000);
     }
 
     /**

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
@@ -1465,11 +1465,13 @@ public class RadioAudioService extends Service {
             Log.v("firmware", new String(param));
         } else if (cmd == COMMAND_HELLO) {
             gotHello = true;
-            audioTrack.stop();
+            if (audioTrack != null) {
+                audioTrack.stop();
+                restartAudioPrebuffer();
+            }
             if (callbacks != null) {
                 callbacks.radioModuleHandshake();
             }
-            restartAudioPrebuffer();
             checkFirmwareVersion();
         } else {
             Log.d("DEBUG", "Unknown cmd received from ESP32: 0x" + Integer.toHexString(cmd & 0xFF) +

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
@@ -975,7 +975,7 @@ public class RadioAudioService extends Service {
         timeOutHandler.removeCallbacksAndMessages(null);
         timeOutHandler.postDelayed(() -> {
             if (!gotHello) {
-                Log.d("DEBUG", "Error: Did not HELLO from module.");
+                Log.d("DEBUG", "Error: No HELLO received from module.");
                 callbacks.missingFirmware();
                 setMode(MODE_BAD_FIRMWARE);
             }

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
@@ -1738,7 +1738,7 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void showHandshakeSnackbar() {
-        CharSequence snackbarMsg = "kv4p HT radio handshake.";
+        CharSequence snackbarMsg = "Connecting to radio...";
         usbSnackbar = Snackbar.make(this, findViewById(R.id.mainTopLevelLayout), snackbarMsg, Snackbar.LENGTH_INDEFINITE)
             .setBackgroundTint(Color.rgb(20, 140, 0)).setActionTextColor(Color.WHITE).setTextColor(Color.WHITE)
             .setAnchorView(findViewById(R.id.bottomNavigationView));

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
@@ -324,6 +324,13 @@ public class MainActivity extends AppCompatActivity {
 
                 @Override
                 public void radioConnected() {
+                    hideSnackbar();
+                    applySettings();
+                    findViewById(R.id.pttButton).setClickable(true);
+                }
+
+                @Override
+                public void hideSnackbar() {
                     if (usbSnackbar != null) {
                         usbSnackbar.dismiss();
                         usbSnackbar = null;
@@ -336,8 +343,12 @@ public class MainActivity extends AppCompatActivity {
                         radioModuleNotFoundSnackbar.dismiss();
                         radioModuleNotFoundSnackbar = null;
                     }
-                    applySettings();
-                    findViewById(R.id.pttButton).setClickable(true);
+
+                }
+
+                @Override
+                public void radioModuleHandshake() {
+                    showHandshakeSnackbar();
                 }
 
                 @Override
@@ -1715,6 +1726,21 @@ public class MainActivity extends AppCompatActivity {
         CharSequence snackbarMsg = "kv4p HT radio not found, plugged in?";
         usbSnackbar = Snackbar.make(this, findViewById(R.id.mainTopLevelLayout), snackbarMsg, Snackbar.LENGTH_INDEFINITE)
             .setBackgroundTint(Color.rgb(140, 20, 0)).setActionTextColor(Color.WHITE).setTextColor(Color.WHITE)
+            .setAnchorView(findViewById(R.id.bottomNavigationView));
+
+        // Make the text of the snackbar larger.
+        TextView snackbarActionTextView = (TextView) usbSnackbar.getView().findViewById(com.google.android.material.R.id.snackbar_action);
+        snackbarActionTextView.setTextSize(20);
+        TextView snackbarTextView = (TextView) usbSnackbar.getView().findViewById(com.google.android.material.R.id.snackbar_text);
+        snackbarTextView.setTextSize(20);
+
+        usbSnackbar.show();
+    }
+
+    private void showHandshakeSnackbar() {
+        CharSequence snackbarMsg = "kv4p HT radio handshake.";
+        usbSnackbar = Snackbar.make(this, findViewById(R.id.mainTopLevelLayout), snackbarMsg, Snackbar.LENGTH_INDEFINITE)
+            .setBackgroundTint(Color.rgb(20, 140, 0)).setActionTextColor(Color.WHITE).setTextColor(Color.WHITE)
             .setAnchorView(findViewById(R.id.bottomNavigationView));
 
         // Make the text of the snackbar larger.

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/globals.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/globals.h
@@ -48,6 +48,7 @@ const byte COMMAND_DEBUG_ERROR    = 0x02;
 const byte COMMAND_DEBUG_WARN     = 0x03;
 const byte COMMAND_DEBUG_DEBUG    = 0x04;
 const byte COMMAND_DEBUG_TRACE    = 0x05;
+const byte COMMAND_HELLO          = 0x06;
 
 // Mode of the app, which is essentially a state machine
 enum Mode {

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
@@ -152,6 +152,7 @@ void setup() {
   squelched = (digitalRead(SQ_PIN) == HIGH);
   setMode(MODE_STOPPED);
   ledSetup();
+  sendCmdToAndroid(COMMAND_HELLO, NULL, 0);
   _LOGI("Setup is finished");
 }
 

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
@@ -315,7 +315,7 @@ void loop() {
             while (result != 1) {
               result = dra->handshake();  // Wait for module to start up
               // Serial.println("handshake: " + String(result));
-
+              esp_task_wdt_reset();
               if ((micros() - waitStart) > 2000000) {  // Give the radio module 2 seconds max before giving up on it
                 radioModuleStatus = RADIO_MODULE_NOT_FOUND;
                 break;


### PR DESCRIPTION
Currently, the host waits for an arbitrary delay after a USB connect event before sending a GET_VERSION request to determine if the module is ready. This can lead to timing issues and unreliable initialization.

This PR updates the handshake process so that the module proactively sends a HELLO message after boot. This ensures the host knows exactly when the module is ready, improving reliability and reducing unnecessary delays.

Changes:

1. The module now sends a HELLO message immediately after boot.
2. The host listens for the HELLO message before proceeding with further communication.
3. If no HELLO is received within a timeout period, the host prompts for flash

Benefits:

1. Eliminates reliance on arbitrary delays.
2. Ensures the host only communicates when the module is actually ready.
3. Improves reliability, especially in cases where boot time varies.
4. allows to re-sync after module reboot in RX mode
