### PR TITLE
Refactor ESP32 to Host Stream

### DIFF
--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/ESP32DataStreamParser.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/ESP32DataStreamParser.java
@@ -17,7 +17,7 @@ public class ESP32DataStreamParser {
         this.onCommand = onCommand;
     }
 
-    public void extractAudioAndHandleCommands(byte[] newData) {
+    public void handleCommands(byte[] newData) {
         for (byte b : newData) {
             if (matchedDelimiterTokens < COMMAND_DELIMITER.length) {
                 if (b == COMMAND_DELIMITER[matchedDelimiterTokens]) {

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/ESP32DataStreamParser.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/ESP32DataStreamParser.java
@@ -11,23 +11,18 @@ public class ESP32DataStreamParser {
     private byte command;
     private int commandParamLen;
     private final ByteArrayOutputStream commandParams = new ByteArrayOutputStream();
-    private final ByteArrayOutputStream lookaheadBuffer = new ByteArrayOutputStream();
-
     private final BiConsumer<Byte, byte[]> onCommand;
 
     public ESP32DataStreamParser(BiConsumer<Byte, byte[]> onCommand) {
         this.onCommand = onCommand;
     }
 
-    public byte[] extractAudioAndHandleCommands(byte[] newData) {
-        ByteArrayOutputStream audioOut = new ByteArrayOutputStream();
+    public void extractAudioAndHandleCommands(byte[] newData) {
         for (byte b : newData) {
-            lookaheadBuffer.write(b);
             if (matchedDelimiterTokens < COMMAND_DELIMITER.length) {
                 if (b == COMMAND_DELIMITER[matchedDelimiterTokens]) {
                     matchedDelimiterTokens++;
                 } else {
-                    flushLookaheadBuffer(audioOut);
                     matchedDelimiterTokens = 0;
                 }
             } else if (matchedDelimiterTokens == COMMAND_DELIMITER.length) {
@@ -40,30 +35,21 @@ public class ESP32DataStreamParser {
                 matchedDelimiterTokens++;
                 if (commandParamLen == 0) { // If this command has no params...
                     onCommand.accept(command, commandParams.toByteArray());
-                    resetParser(audioOut);
+                    resetParser();
                 }
             } else {
                 commandParams.write(b);
                 matchedDelimiterTokens++;
-                lookaheadBuffer.reset();
                 if (commandParams.size() == commandParamLen) {
                     // Log.d("DEBUG", "commandParams: " + commandParams);
                     onCommand.accept(command, commandParams.toByteArray());
-                    resetParser(audioOut);
+                    resetParser();
                 }
             }
         }
-        return audioOut.toByteArray();
     }
 
-    private void flushLookaheadBuffer(ByteArrayOutputStream audioOut) {
-        byte[] buffer = lookaheadBuffer.toByteArray();
-        audioOut.write(buffer, 0, buffer.length);
-        lookaheadBuffer.reset();
-    }
-
-    private void resetParser(ByteArrayOutputStream audioOut) {
-        flushLookaheadBuffer(audioOut);
+    private void resetParser() {
         matchedDelimiterTokens = 0;
         commandParams.reset();
         commandParamLen = 0;

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/ESP32DataStreamParser.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/ESP32DataStreamParser.java
@@ -20,20 +20,15 @@ public class ESP32DataStreamParser {
     public void handleCommands(byte[] newData) {
         for (byte b : newData) {
             if (matchedDelimiterTokens < COMMAND_DELIMITER.length) {
-                if (b == COMMAND_DELIMITER[matchedDelimiterTokens]) {
-                    matchedDelimiterTokens++;
-                } else {
-                    matchedDelimiterTokens = 0;
-                }
+                matchedDelimiterTokens = (b == COMMAND_DELIMITER[matchedDelimiterTokens]) ? matchedDelimiterTokens + 1 : 0;
             } else if (matchedDelimiterTokens == COMMAND_DELIMITER.length) {
                 command = b;
-                // Log.d("DEBUG", "command: " + command);
                 matchedDelimiterTokens++;
             } else if (matchedDelimiterTokens == COMMAND_DELIMITER.length + 1) {
                 commandParamLen = b & 0xFF;
                 commandParams.reset();
                 matchedDelimiterTokens++;
-                if (commandParamLen == 0) { // If this command has no params...
+                if (commandParamLen == 0) {
                     onCommand.accept(command, commandParams.toByteArray());
                     resetParser();
                 }
@@ -41,7 +36,6 @@ public class ESP32DataStreamParser {
                 commandParams.write(b);
                 matchedDelimiterTokens++;
                 if (commandParams.size() == commandParamLen) {
-                    // Log.d("DEBUG", "commandParams: " + commandParams);
                     onCommand.accept(command, commandParams.toByteArray());
                     resetParser();
                 }

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/FirmwareVersion.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/FirmwareVersion.java
@@ -3,6 +3,8 @@ package com.vagell.kv4pht.radio;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
+import org.jetbrains.annotations.NotNull;
+
 public class FirmwareVersion {
 
     private final short ver;  // equivalent to uint16_t
@@ -27,5 +29,14 @@ public class FirmwareVersion {
 
     public HardwareVersion getHardwareVersion() {
         return hardwareVersion;
+    }
+
+    @Override
+    public @NotNull String toString() {
+        return "FirmwareVersion {" +
+            "ver=" + ver +
+            ", radioModuleStatus=" + getRadioModuleStatus() +
+            ", hardwareVersion=" + getHardwareVersion() +
+            '}';
     }
 }

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/FirmwareVersion.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/FirmwareVersion.java
@@ -7,12 +7,14 @@ public class FirmwareVersion {
 
     private final short ver;  // equivalent to uint16_t
     private final byte radioModuleStatus;  // equivalent to char
+    private final HardwareVersion hardwareVersion;
 
     public FirmwareVersion(final byte[] param) {
         ByteBuffer buffer = ByteBuffer.wrap(param);
         buffer.order(ByteOrder.LITTLE_ENDIAN);
         this.ver = buffer.getShort();  // Read the 16-bit unsigned value
         this.radioModuleStatus = buffer.get();  // Read the 8-bit char (1 byte)
+        this.hardwareVersion = HardwareVersion.fromValue(buffer.get() & 0xFF);  // Read the 8-bit char (1 byte)
     }
 
     public short getVer() {
@@ -21,5 +23,9 @@ public class FirmwareVersion {
 
     public String getRadioModuleStatus() {
         return String.valueOf((char) radioModuleStatus);
+    }
+
+    public HardwareVersion getHardwareVersion() {
+        return hardwareVersion;
     }
 }

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/FirmwareVersion.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/FirmwareVersion.java
@@ -1,0 +1,26 @@
+package com.vagell.kv4pht.radio;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+public class FirmwareVersion {
+
+    private final short ver;  // equivalent to uint16_t
+    private final byte radioModuleStatus;  // equivalent to char
+
+    public FirmwareVersion(final byte[] param) {
+        ByteBuffer buffer = ByteBuffer.wrap(param);
+        buffer.order(ByteOrder.LITTLE_ENDIAN);  // Ensure the correct byte order (adjust to platform if necessary)
+        // Unpack the data from the buffer
+        this.ver = buffer.getShort();  // Read the 16-bit unsigned value
+        this.radioModuleStatus = buffer.get();  // Read the 8-bit char (1 byte)
+    }
+
+    public short getVer() {
+        return ver;
+    }
+
+    public String getRadioModuleStatus() {
+        return String.valueOf((char) radioModuleStatus);
+    }
+}

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/FirmwareVersion.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/FirmwareVersion.java
@@ -10,8 +10,7 @@ public class FirmwareVersion {
 
     public FirmwareVersion(final byte[] param) {
         ByteBuffer buffer = ByteBuffer.wrap(param);
-        buffer.order(ByteOrder.LITTLE_ENDIAN);  // Ensure the correct byte order (adjust to platform if necessary)
-        // Unpack the data from the buffer
+        buffer.order(ByteOrder.LITTLE_ENDIAN);
         this.ver = buffer.getShort();  // Read the 16-bit unsigned value
         this.radioModuleStatus = buffer.get();  // Read the 8-bit char (1 byte)
     }

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/HardwareVersion.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/HardwareVersion.java
@@ -1,0 +1,27 @@
+package com.vagell.kv4pht.radio;
+
+public enum HardwareVersion {
+
+    HW_VER_V1(0x00),
+    HW_VER_V2_0C(0xFF),
+    HW_VER_V2_0D(0xF0);
+
+    private final int value;
+
+    HardwareVersion(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public static HardwareVersion fromValue(int value) {
+        for (HardwareVersion version : HardwareVersion.values()) {
+            if (version.getValue() == value) {
+                return version;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value: " + value);
+    }
+}

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
@@ -106,11 +106,6 @@ public class RadioAudioService extends Service {
     private static final int[] ESP32_VENDOR_IDS = {4292, 6790};
     private static final int[] ESP32_PRODUCT_IDS = {60000, 29987};
 
-    // Version related constants (also see FirmwareUtils for others)
-    private static final String VERSION_PREFIX = "VERSION";
-    private static String versionStrBuffer = "";
-    private static final int VERSION_LENGTH = 8; // Chars in the version string from ESP32 app.
-
     public static final int MODE_STARTUP = -1;
     public static final int MODE_RX = 0;
     public static final int MODE_TX = 1;
@@ -1354,7 +1349,6 @@ public class RadioAudioService extends Service {
                 Log.d("DEBUG", "Error: ESP32 app firmware " + ver.getVer() + " is older than latest firmware " + FirmwareUtils.PACKAGED_FIRMWARE_VER);
                 if (callbacks != null) {
                     callbacks.outdatedFirmware(ver.getVer());
-                    versionStrBuffer = "";
                 }
             } else {
                 Log.d("DEBUG", "Recent ESP32 app firmware version detected (" + ver.getVer() + ").");

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
@@ -140,10 +140,6 @@ public class RadioAudioService extends Service {
 
     // For receiving audio from ESP32 / radio
     private AudioTrack audioTrack;
-    private static final int PRE_BUFFER_SIZE = 256;
-    private byte[] rxBytesPrebuffer = new byte[PRE_BUFFER_SIZE];
-    private int rxPrebufferIdx = 0;
-    private boolean prebufferComplete = false;
     private static final float SEC_BETWEEN_SCANS = 0.5f; // how long to wait during silence to scan to next frequency in scan mode
     private LiveData<List<ChannelMemory>> channelMemoriesLiveData = null;
 

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
@@ -918,7 +918,7 @@ public class RadioAudioService extends Service {
         usbIoManager = new SerialInputOutputManager(serialPort, new SerialInputOutputManager.Listener() {
             @Override
             public void onNewData(byte[] data) {
-                esp32DataStreamParser.extractAudioAndHandleCommands(data);
+                esp32DataStreamParser.handleCommands(data);
             }
 
             @Override

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
@@ -18,17 +18,35 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 package com.vagell.kv4pht.radio;
 
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
+import android.Manifest;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbDeviceConnection;
+import android.hardware.usb.UsbManager;
+import android.location.Location;
+import android.location.LocationManager;
+import android.media.AudioAttributes;
+import android.media.AudioFormat;
+import android.media.AudioManager;
+import android.media.AudioRecord;
+import android.media.AudioTrack;
+import android.os.Binder;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.IBinder;
+import android.os.Looper;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.core.app.ActivityCompat;
+import androidx.core.app.NotificationCompat;
+import androidx.lifecycle.LiveData;
 
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
@@ -62,35 +80,17 @@ import com.vagell.kv4pht.ui.MainActivity;
 
 import org.apache.commons.lang3.ArrayUtils;
 
-import android.Manifest;
-import android.app.NotificationChannel;
-import android.app.NotificationManager;
-import android.app.PendingIntent;
-import android.app.Service;
-import android.content.Context;
-import android.content.Intent;
-import android.content.pm.PackageManager;
-import android.hardware.usb.UsbDevice;
-import android.hardware.usb.UsbDeviceConnection;
-import android.hardware.usb.UsbManager;
-import android.location.Location;
-import android.location.LocationManager;
-import android.media.AudioAttributes;
-import android.media.AudioFormat;
-import android.media.AudioManager;
-import android.media.AudioRecord;
-import android.media.AudioTrack;
-import android.os.Binder;
-import android.os.Bundle;
-import android.os.Handler;
-import android.os.IBinder;
-import android.os.Looper;
-import android.util.Log;
-import androidx.annotation.NonNull;
-import androidx.core.app.ActivityCompat;
-import androidx.core.app.NotificationCompat;
-import androidx.lifecycle.LiveData;
-
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 /**
  * Background service that manages the connection to the ESP32 (to control the radio), and
  * handles playing back any audio received from the radio. This frees up the rest of the

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
@@ -1316,9 +1316,7 @@ public class RadioAudioService extends Service {
                     callbacks.outdatedFirmware(ver.getVer());
                 }
             } else {
-                Log.d("DEBUG", "Recent ESP32 app firmware version detected (" + ver.getVer() + ").");
-                Log.d("DEBUG", "Radio status: '" + ver.getRadioModuleStatus() + "'");
-
+                Log.d("DEBUG", "Recent ESP32 app firmware version detected (" + ver + ").");
                 if (ver.getRadioModuleStatus().equals(RADIO_MODULE_NOT_FOUND)) {
                     radioModuleNotFound = true;
                 } else if (ver.getRadioModuleStatus().equals(RADIO_MODULE_FOUND)) {

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
@@ -1254,42 +1254,7 @@ public class RadioAudioService extends Service {
 
     private void handleParsedCommand(byte cmd, byte[] param) {
         if (cmd == COMMAND_SMETER_REPORT) {
-            if (param.length >= 1) {
-                int sMeter255Value = (param[0] & 0xFF);
-                // Log.d("DEBUG", "Raw s-meter value from ESP32 (0-255) = " + sMeter255Value);
-
-                // Through empirical testing, it seems to scale from ~50 with no signal, and ~120 with a transmitter
-                // right near it. So we normalize to match that to an S1-S9 scale. Note, we start more granular at
-                // lower S-values so people can get a better sense of weak signals. This isn't a scientific db measurement...
-                int sMeter9Value = 1;
-                if (sMeter255Value >= 46) {
-                    sMeter9Value = 2;
-                }
-                if (sMeter255Value >= 50) {
-                    sMeter9Value = 3;
-                }
-                if (sMeter255Value >= 55) {
-                    sMeter9Value = 4;
-                }
-                if (sMeter255Value >= 61) {
-                    sMeter9Value = 5;
-                }
-                if (sMeter255Value >= 68) {
-                    sMeter9Value = 6;
-                }
-                if (sMeter255Value >= 76) {
-                    sMeter9Value = 7;
-                }
-                if (sMeter255Value >= 87) {
-                    sMeter9Value = 8;
-                }
-                if (sMeter255Value >= 101) {
-                    sMeter9Value = 9;
-                }
-                // Log.d("DEBUG", "Normalized s-meter (0-9) = " + sMeter9Value);
-
-                callbacks.sMeterUpdate(sMeter9Value);
-            }
+            callbacks.sMeterUpdate(new Rssi(param).getSMeter9Value());
         } else if (cmd == COMMAND_PHYS_PTT_DOWN) {
             if (mode == MODE_RX) { // Note that people can't hit PTT in the middle of a scan.
                 startPtt();

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/Rssi.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/Rssi.java
@@ -1,28 +1,32 @@
 package com.vagell.kv4pht.radio;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
 public class Rssi {
 
     private final int sMeter9Value;
+    private static final Map<Integer, Integer> sMeterMap = new HashMap<>();
 
-    public Rssi(final byte[] param) {
-        if (param.length == 1) {
-            int sMeter255Value = param[0] & 0xFF;
-            this.sMeter9Value = calculateSMeter9Value(sMeter255Value);
-        } else {
-            this.sMeter9Value = 0;
-        }
+    static {
+        for (int i = 101; i <= 255; i++) sMeterMap.put(i, 9);
+        for (int i = 87; i < 101; i++) sMeterMap.put(i, 8);
+        for (int i = 76; i < 87; i++) sMeterMap.put(i, 7);
+        for (int i = 68; i < 76; i++) sMeterMap.put(i, 6);
+        for (int i = 61; i < 68; i++) sMeterMap.put(i, 5);
+        for (int i = 55; i < 61; i++) sMeterMap.put(i, 4);
+        for (int i = 50; i < 55; i++) sMeterMap.put(i, 3);
+        for (int i = 46; i < 50; i++) sMeterMap.put(i, 2);
+        for (int i = 0; i < 46; i++) sMeterMap.put(i, 1);
     }
 
-    private int calculateSMeter9Value(int sMeter255Value) {
-        if (sMeter255Value >= 101) return 9;
-        if (sMeter255Value >= 87) return 8;
-        if (sMeter255Value >= 76) return 7;
-        if (sMeter255Value >= 68) return 6;
-        if (sMeter255Value >= 61) return 5;
-        if (sMeter255Value >= 55) return 4;
-        if (sMeter255Value >= 50) return 3;
-        if (sMeter255Value >= 46) return 2;
-        return 1;
+    public Rssi(final byte[] param) {
+        this.sMeter9Value = Optional.ofNullable(param)
+            .filter(p -> p.length == 1)
+            .map(p -> p[0] & 0xFF)
+            .map(sMeterMap::get)
+            .orElse(0);
     }
 
     public int getSMeter9Value() {

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/Rssi.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/Rssi.java
@@ -1,32 +1,22 @@
 package com.vagell.kv4pht.radio;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 
 public class Rssi {
 
     private final int sMeter9Value;
-    private static final Map<Integer, Integer> sMeterMap = new HashMap<>();
-
-    static {
-        for (int i = 101; i <= 255; i++) sMeterMap.put(i, 9);
-        for (int i = 87; i < 101; i++) sMeterMap.put(i, 8);
-        for (int i = 76; i < 87; i++) sMeterMap.put(i, 7);
-        for (int i = 68; i < 76; i++) sMeterMap.put(i, 6);
-        for (int i = 61; i < 68; i++) sMeterMap.put(i, 5);
-        for (int i = 55; i < 61; i++) sMeterMap.put(i, 4);
-        for (int i = 50; i < 55; i++) sMeterMap.put(i, 3);
-        for (int i = 46; i < 50; i++) sMeterMap.put(i, 2);
-        for (int i = 0; i < 46; i++) sMeterMap.put(i, 1);
-    }
-
+    
     public Rssi(final byte[] param) {
         this.sMeter9Value = Optional.ofNullable(param)
             .filter(p -> p.length == 1)
             .map(p -> p[0] & 0xFF)
-            .map(sMeterMap::get)
+            .map(this::calculateSMeter9Value)
             .orElse(0);
+    }
+
+    private int calculateSMeter9Value(int sMeter255Value) {
+        double result = 9.73 * Math.log(0.0297 * sMeter255Value) - 1.88;
+        return Math.max(1, Math.min(9, (int) Math.round(result)));
     }
 
     public int getSMeter9Value() {

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/Rssi.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/Rssi.java
@@ -1,0 +1,31 @@
+package com.vagell.kv4pht.radio;
+
+public class Rssi {
+
+    private final int sMeter9Value;
+
+    public Rssi(final byte[] param) {
+        if (param.length == 1) {
+            int sMeter255Value = param[0] & 0xFF;
+            this.sMeter9Value = calculateSMeter9Value(sMeter255Value);
+        } else {
+            this.sMeter9Value = 0;
+        }
+    }
+
+    private int calculateSMeter9Value(int sMeter255Value) {
+        if (sMeter255Value >= 101) return 9;
+        if (sMeter255Value >= 87) return 8;
+        if (sMeter255Value >= 76) return 7;
+        if (sMeter255Value >= 68) return 6;
+        if (sMeter255Value >= 61) return 5;
+        if (sMeter255Value >= 55) return 4;
+        if (sMeter255Value >= 50) return 3;
+        if (sMeter255Value >= 46) return 2;
+        return 1;
+    }
+
+    public int getSMeter9Value() {
+        return sMeter9Value;
+    }
+}

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/debug.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/debug.h
@@ -60,7 +60,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   }
   #endif
 
-int debug_log_printf(uint8_t cmd, const char* format, ...) {
+int debug_log_printf(Esp32ToHost cmd, const char* format, ...) {
   static char loc_buf[256];
   char* temp = loc_buf;
   int len;

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/debug.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/debug.h
@@ -77,7 +77,7 @@ int debug_log_printf(Esp32ToHost cmd, const char* format, ...) {
     }
   }
   vsnprintf(temp, len + 1, format, arg);
-  sendCmdToAndroid(cmd, (byte*) temp, len);
+  sendCmdToHost(cmd, (byte*) temp, len);
   va_end(arg);
   if (len >= sizeof(loc_buf)) {
     free(temp);

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/debug.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/debug.h
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <Arduino.h>
 #include "globals.h"
+#include "protocol.h"
 
 #ifndef RELEASE
 #define _LOGE(fmt, ...)           \

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/debug.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/debug.h
@@ -77,7 +77,7 @@ int debug_log_printf(Esp32ToHost cmd, const char* format, ...) {
     }
   }
   vsnprintf(temp, len + 1, format, arg);
-  sendCmdToHost(cmd, (byte*) temp, len);
+  __sendCmdToHost(cmd, (byte*) temp, len);
   va_end(arg);
   if (len >= sizeof(loc_buf)) {
     free(temp);

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/globals.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/globals.h
@@ -31,25 +31,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 typedef uint8_t hw_ver_t;  // This allows us to do a lot more in the future if we want.
 hw_ver_t hardware_version = HW_VER_V1;  // lowest common denominator
 
-// Commands defined here must match the Android app
-const uint8_t COMMAND_PTT_DOWN         = 1;  // start transmitting audio that Android app will send
-const uint8_t COMMAND_PTT_UP           = 2;  // stop transmitting audio, go into RX mode
-const uint8_t COMMAND_TUNE_TO          = 3;  // change the frequency
-const uint8_t COMMAND_FILTERS          = 4;  // toggle filters on/off
-const uint8_t COMMAND_STOP             = 5;  // stop everything, just wait for next command
-const uint8_t COMMAND_GET_FIRMWARE_VER = 6;  // report FIRMWARE_VER in the format '00000001' for 1 (etc.)
-
-// Outgoing commands (ESP32 -> Android)
-const byte COMMAND_SMETER_REPORT  = 0x53; // 'S'
-const byte COMMAND_PHYS_PTT_DOWN  = 0x44; // 'D'
-const byte COMMAND_PHYS_PTT_UP    = 0x55; // 'U'
-const byte COMMAND_DEBUG_INFO     = 0x01;
-const byte COMMAND_DEBUG_ERROR    = 0x02;
-const byte COMMAND_DEBUG_WARN     = 0x03;
-const byte COMMAND_DEBUG_DEBUG    = 0x04;
-const byte COMMAND_DEBUG_TRACE    = 0x05;
-const byte COMMAND_HELLO          = 0x06;
-
 // Mode of the app, which is essentially a state machine
 enum Mode {
   MODE_TX,

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/globals.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/globals.h
@@ -53,4 +53,3 @@ void processTxAudio(uint8_t tempBuffer[], int bytesRead);
 void iir_lowpass_reset();
 hw_ver_t get_hardware_version();
 void reportPhysPttState();
-void sendCmdToAndroid(byte cmdByte, const byte *params, size_t paramsLen);

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
@@ -148,7 +148,7 @@ void setup() {
   squelched = (digitalRead(SQ_PIN) == HIGH);
   setMode(MODE_STOPPED);
   ledSetup();
-  sendCmdToHost(COMMAND_HELLO);
+  sendHello();
   _LOGI("Setup is finished");
 }
 
@@ -329,12 +329,7 @@ void loop() {
               result = dra->volume(8);
             }
             result = dra->filters(false, false, false);
-            Version params = {
-              .ver = FIRMWARE_VER,
-              .radioModuleStatus = radioModuleStatus,
-              .hw = hardware_version
-            };
-            sendCmdToHost(COMMAND_VERSION, (uint8_t*) &params, sizeof(params));
+            sendVersion(FIRMWARE_VER, radioModuleStatus, hardware_version);
             esp_task_wdt_reset();
             return;
           }
@@ -532,10 +527,7 @@ void loop() {
           String rssiStr = rssiResponse.substring(5);
           int rssiInt    = rssiStr.toInt();
           if (rssiInt >= 0 && rssiInt <= 255) {
-            Rssi params = {
-              .val = (uint8_t)rssiInt
-            };
-            sendCmdToHost(COMMAND_SMETER_REPORT, (uint8_t*) &params, sizeof(params));
+            sendRssi((uint8_t)rssiInt);
           }
         }
 
@@ -556,7 +548,7 @@ void loop() {
           int16_t sample = remove_dc(2048 - (int16_t)(buffer16[i] & 0xfff));
           buffer8[i]     = squelched ? 0 : (sample >> 4);  // Signed
         }
-        sendCmdToHost(COMMAND_RX_AUDIO, buffer8, samplesRead);
+        sendAudio(buffer8, samplesRead);
       }
     } else if (mode == MODE_TX) {
       // Check for runaway tx
@@ -691,7 +683,7 @@ void processTxAudio(uint8_t tempBuffer[], int bytesRead) {
 }
 
 void reportPhysPttState() {
-  sendCmdToHost(isPhysPttDown ? COMMAND_PHYS_PTT_DOWN : COMMAND_PHYS_PTT_UP);
+  sendPhysPttState(isPhysPttDown);
 }
 
 hw_ver_t get_hardware_version() {

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
@@ -29,7 +29,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "led.h"
 #include "protocol.h"
 
-const uint16_t FIRMWARE_VER = 12;  // Should be 8 characters representing a zero-padded version, like 00000001.
+const uint16_t FIRMWARE_VER = 12;
 
 // S-meter interval
 long lastSMeterReport = -1;

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
@@ -329,12 +329,12 @@ void loop() {
               result = dra->volume(8);
             }
             result = dra->filters(false, false, false);
-            Version reply = {
+            Version params = {
               .ver = FIRMWARE_VER,
               .radioModuleStatus = radioModuleStatus,
               .hw = hardware_version
             };
-            sendCmdToHost(COMMAND_VERSION, (uint8_t*) &reply, sizeof(reply));
+            sendCmdToHost(COMMAND_VERSION, (uint8_t*) &params, sizeof(params));
             esp_task_wdt_reset();
             return;
           }

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
@@ -530,12 +530,12 @@ void loop() {
         if (rssiResponse.length() > 7) {
           String rssiStr = rssiResponse.substring(5);
           int rssiInt    = rssiStr.toInt();
-
           if (rssiInt >= 0 && rssiInt <= 255) {
-            byte params[1] = {(uint8_t)rssiInt};
-            sendCmdToAndroid(COMMAND_SMETER_REPORT, params, /* paramsLen */ 1);
+            Rssi params = {
+              .val = (uint8_t)rssiInt
+            };
+            sendCmdToAndroid(COMMAND_SMETER_REPORT, (uint8_t*) &params, sizeof(params));
           }
-          //_LOGD("%s, rssiInt=%d", rssiResponse.c_str(), rssiInt);
         }
 
         // It doesn't matter if we successfully got the S-meter reading, we only want to check at most once every SMETER_REPORT_INTERVAL_MS

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
@@ -148,7 +148,7 @@ void setup() {
   squelched = (digitalRead(SQ_PIN) == HIGH);
   setMode(MODE_STOPPED);
   ledSetup();
-  sendCmdToAndroid(COMMAND_HELLO, NULL, 0);
+  sendCmdToAndroid(COMMAND_HELLO);
   _LOGI("Setup is finished");
 }
 
@@ -632,32 +632,6 @@ void loop() {
   }
 }
 
-/**
- * Send a command with params
- * Format: [DELIMITER(8 bytes)] [CMD(1 byte)] [paramLen(1 byte)] [param data(N bytes)]
- */
-void sendCmdToAndroid(byte cmdByte, const byte *params, size_t paramsLen) {
-  // Safety check: limit paramsLen to 255 for 1-byte length
-  if (paramsLen > 255) {
-    paramsLen = 255;  // or handle differently (split, or error, etc.)
-  }
-
-  // 1. Leading delimiter
-  Serial.write(COMMAND_DELIMITER, DELIMITER_LENGTH);
-
-  // 2. Command byte
-  Serial.write(&cmdByte, 1);
-
-  // 3. Parameter length
-  uint8_t len = paramsLen;
-  Serial.write(&len, 1);
-
-  if (paramsLen > 0) {
-    // 4. Parameter bytes
-    Serial.write(params, paramsLen);
-  }
-}
-
 void tuneTo(float freqTx, float freqRx, int txTone, int rxTone, int squelch, String bandwidth) {
   // Tell radio module to tune
   int result = 0;
@@ -717,7 +691,7 @@ void processTxAudio(uint8_t tempBuffer[], int bytesRead) {
 }
 
 void reportPhysPttState() {
-  sendCmdToAndroid(isPhysPttDown ? COMMAND_PHYS_PTT_DOWN : COMMAND_PHYS_PTT_UP, NULL, 0);
+  sendCmdToAndroid(isPhysPttDown ? COMMAND_PHYS_PTT_DOWN : COMMAND_PHYS_PTT_UP);
 }
 
 hw_ver_t get_hardware_version() {

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
@@ -331,7 +331,8 @@ void loop() {
             result = dra->filters(false, false, false);
             Version reply = {
               .ver = FIRMWARE_VER,
-              .radioModuleStatus = radioModuleStatus
+              .radioModuleStatus = radioModuleStatus,
+              .hw = hardware_version
             };
             sendCmdToAndroid(COMMAND_VERSION, (uint8_t*) &reply, sizeof(reply));
             esp_task_wdt_reset();

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
@@ -148,7 +148,7 @@ void setup() {
   squelched = (digitalRead(SQ_PIN) == HIGH);
   setMode(MODE_STOPPED);
   ledSetup();
-  sendCmdToAndroid(COMMAND_HELLO);
+  sendCmdToHost(COMMAND_HELLO);
   _LOGI("Setup is finished");
 }
 
@@ -334,7 +334,7 @@ void loop() {
               .radioModuleStatus = radioModuleStatus,
               .hw = hardware_version
             };
-            sendCmdToAndroid(COMMAND_VERSION, (uint8_t*) &reply, sizeof(reply));
+            sendCmdToHost(COMMAND_VERSION, (uint8_t*) &reply, sizeof(reply));
             esp_task_wdt_reset();
             return;
           }
@@ -535,7 +535,7 @@ void loop() {
             Rssi params = {
               .val = (uint8_t)rssiInt
             };
-            sendCmdToAndroid(COMMAND_SMETER_REPORT, (uint8_t*) &params, sizeof(params));
+            sendCmdToHost(COMMAND_SMETER_REPORT, (uint8_t*) &params, sizeof(params));
           }
         }
 
@@ -556,7 +556,7 @@ void loop() {
           int16_t sample = remove_dc(2048 - (int16_t)(buffer16[i] & 0xfff));
           buffer8[i]     = squelched ? 0 : (sample >> 4);  // Signed
         }
-        sendCmdToAndroid(COMMAND_RX_AUDIO, buffer8, samplesRead);
+        sendCmdToHost(COMMAND_RX_AUDIO, buffer8, samplesRead);
       }
     } else if (mode == MODE_TX) {
       // Check for runaway tx
@@ -691,7 +691,7 @@ void processTxAudio(uint8_t tempBuffer[], int bytesRead) {
 }
 
 void reportPhysPttState() {
-  sendCmdToAndroid(isPhysPttDown ? COMMAND_PHYS_PTT_DOWN : COMMAND_PHYS_PTT_UP);
+  sendCmdToHost(isPhysPttDown ? COMMAND_PHYS_PTT_DOWN : COMMAND_PHYS_PTT_UP);
 }
 
 hw_ver_t get_hardware_version() {

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/protocol.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/protocol.h
@@ -17,28 +17,56 @@ const uint8_t COMMAND_STOP             = 5;  // stop everything, just wait for n
 const uint8_t COMMAND_GET_FIRMWARE_VER = 6;  // reply with [COMMAND_VERSION(Version)]
 
 // Outgoing commands (ESP32 -> Android)
-const uint8_t COMMAND_SMETER_REPORT  = 0x53; // [COMMAND_SMETER_REPORT(Rssi)]
-const uint8_t COMMAND_PHYS_PTT_DOWN  = 0x44; // [COMMAND_PHYS_PTT_DOWN()]
-const uint8_t COMMAND_PHYS_PTT_UP    = 0x55; // [COMMAND_PHYS_PTT_UP()]
-const uint8_t COMMAND_DEBUG_INFO     = 0x01; // [COMMAND_DEBUG_INFO(char[])]
-const uint8_t COMMAND_DEBUG_ERROR    = 0x02; // [COMMAND_DEBUG_ERROR(char[])]
-const uint8_t COMMAND_DEBUG_WARN     = 0x03; // [COMMAND_DEBUG_WARN(char[])]
-const uint8_t COMMAND_DEBUG_DEBUG    = 0x04; // [COMMAND_DEBUG_DEBUG(char[])]
-const uint8_t COMMAND_DEBUG_TRACE    = 0x05; // [COMMAND_DEBUG_TRACE(char[])]
-const uint8_t COMMAND_HELLO          = 0x06; // [COMMAND_HELLO()]
-const uint8_t COMMAND_RX_AUDIO       = 0x07; // [COMMAND_RX_AUDIO(int8_t[])]
-const uint8_t COMMAND_VERSION        = 0x08; // [COMMAND_VERSION(Version)]
+enum Esp32ToHost {
+  COMMAND_SMETER_REPORT  = 0x53, // [COMMAND_SMETER_REPORT(Rssi)]
+  COMMAND_PHYS_PTT_DOWN  = 0x44, // [COMMAND_PHYS_PTT_DOWN()]
+  COMMAND_PHYS_PTT_UP    = 0x55, // [COMMAND_PHYS_PTT_UP()]
+  COMMAND_DEBUG_INFO     = 0x01, // [COMMAND_DEBUG_INFO(char[])]
+  COMMAND_DEBUG_ERROR    = 0x02, // [COMMAND_DEBUG_ERROR(char[])]
+  COMMAND_DEBUG_WARN     = 0x03, // [COMMAND_DEBUG_WARN(char[])]
+  COMMAND_DEBUG_DEBUG    = 0x04, // [COMMAND_DEBUG_DEBUG(char[])]
+  COMMAND_DEBUG_TRACE    = 0x05, // [COMMAND_DEBUG_TRACE(char[])]
+  COMMAND_HELLO          = 0x06, // [COMMAND_HELLO()]
+  COMMAND_RX_AUDIO       = 0x07, // [COMMAND_RX_AUDIO(int8_t[])]
+  COMMAND_VERSION        = 0x08, // [COMMAND_VERSION(Version)]
+};
 
 // COMMAND_VERSION parameters
 struct version {
-    uint16_t    ver;
-    char        radioModuleStatus;
-    hw_ver_t    hw;
+  uint16_t    ver;
+  char        radioModuleStatus;
+  hw_ver_t    hw;
 } __attribute__((__packed__));
 typedef struct version Version;
 
 // COMMAND_SMETER_REPORT parameters
 struct rssi {
-    uint8_t     val;
+  uint8_t     val;
 } __attribute__((__packed__));
 typedef struct rssi Rssi;
+
+/**
+ * Send a command with params
+ * Format: [DELIMITER(8 bytes)] [CMD(1 byte)] [paramLen(1 byte)] [param data(N bytes)]
+ */
+void sendCmdToAndroid(Esp32ToHost cmd, const byte *params, size_t paramsLen) {
+  // Safety check: limit paramsLen to 255 for 1-byte length
+  if (paramsLen > 255) {
+    paramsLen = 255;  // or handle differently (split, or error, etc.)
+  }
+  // 1. Leading delimiter
+  Serial.write(COMMAND_DELIMITER, DELIMITER_LENGTH);
+  // 2. Command byte
+  Serial.write((uint8_t*) &cmd, 1);
+  // 3. Parameter length
+  uint8_t len = paramsLen;
+  Serial.write(&len, 1);
+  // 4. Parameter bytes
+  if (paramsLen > 0) {
+    Serial.write(params, paramsLen);
+  }
+}
+
+void inline sendCmdToAndroid(Esp32ToHost cmd) {
+  sendCmdToAndroid(cmd, NULL, 0);
+}

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/protocol.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/protocol.h
@@ -35,3 +35,9 @@ struct version {
 } __attribute__((__packed__));
   
 typedef struct version Version;
+
+struct rssi {
+    uint8_t     val;
+} __attribute__((__packed__));
+  
+typedef struct rssi Rssi;

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/protocol.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/protocol.h
@@ -17,28 +17,28 @@ const uint8_t COMMAND_STOP             = 5;  // stop everything, just wait for n
 const uint8_t COMMAND_GET_FIRMWARE_VER = 6;  // report FIRMWARE_VER in the format '00000001' for 1 (etc.)
 
 // Outgoing commands (ESP32 -> Android)
-const byte COMMAND_SMETER_REPORT  = 0x53; // 'S'
-const byte COMMAND_PHYS_PTT_DOWN  = 0x44; // 'D'
-const byte COMMAND_PHYS_PTT_UP    = 0x55; // 'U'
-const byte COMMAND_DEBUG_INFO     = 0x01;
-const byte COMMAND_DEBUG_ERROR    = 0x02;
-const byte COMMAND_DEBUG_WARN     = 0x03;
-const byte COMMAND_DEBUG_DEBUG    = 0x04;
-const byte COMMAND_DEBUG_TRACE    = 0x05;
-const byte COMMAND_HELLO          = 0x06;
-const byte COMMAND_RX_AUDIO       = 0x07;
-const byte COMMAND_VERSION        = 0x08;
+const uint8_t COMMAND_SMETER_REPORT  = 0x53; // 'S'
+const uint8_t COMMAND_PHYS_PTT_DOWN  = 0x44; // 'D'
+const uint8_t COMMAND_PHYS_PTT_UP    = 0x55; // 'U'
+const uint8_t COMMAND_DEBUG_INFO     = 0x01;
+const uint8_t COMMAND_DEBUG_ERROR    = 0x02;
+const uint8_t COMMAND_DEBUG_WARN     = 0x03;
+const uint8_t COMMAND_DEBUG_DEBUG    = 0x04;
+const uint8_t COMMAND_DEBUG_TRACE    = 0x05;
+const uint8_t COMMAND_HELLO          = 0x06;
+const uint8_t COMMAND_RX_AUDIO       = 0x07;
+const uint8_t COMMAND_VERSION        = 0x08;
 
+// COMMAND_VERSION parameters
 struct version {
     uint16_t    ver;
     char        radioModuleStatus;
     hw_ver_t    hw;
 } __attribute__((__packed__));
-  
 typedef struct version Version;
 
+// COMMAND_SMETER_REPORT parameters
 struct rssi {
     uint8_t     val;
 } __attribute__((__packed__));
-  
 typedef struct rssi Rssi;

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/protocol.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/protocol.h
@@ -49,7 +49,7 @@ typedef struct rssi Rssi;
  * Send a command with params
  * Format: [DELIMITER(8 bytes)] [CMD(1 byte)] [paramLen(1 byte)] [param data(N bytes)]
  */
-void sendCmdToHost(Esp32ToHost cmd, const byte *params, size_t paramsLen) {
+void __sendCmdToHost(Esp32ToHost cmd, const byte *params, size_t paramsLen) {
   // Safety check: limit paramsLen to 255 for 1-byte length
   if (paramsLen > 255) {
     paramsLen = 255;  // or handle differently (split, or error, etc.)
@@ -67,6 +67,34 @@ void sendCmdToHost(Esp32ToHost cmd, const byte *params, size_t paramsLen) {
   }
 }
 
-void inline sendCmdToHost(Esp32ToHost cmd) {
-  sendCmdToHost(cmd, NULL, 0);
+void inline __sendCmdToHost(Esp32ToHost cmd) {
+  __sendCmdToHost(cmd, NULL, 0);
+}
+
+void inline sendHello() {
+  __sendCmdToHost(COMMAND_HELLO);
+}
+
+void inline sendRssi(uint8_t rssi) {
+  Rssi params = {
+    .val = rssi
+  };
+  __sendCmdToHost(COMMAND_SMETER_REPORT, (uint8_t*) &params, sizeof(params));
+}
+
+void inline sendVersion(uint16_t ver, char radioModuleStatus, hw_ver_t hw) {
+  Version params = {
+    .ver = ver,
+    .radioModuleStatus = radioModuleStatus,
+    .hw = hw
+  };
+  __sendCmdToHost(COMMAND_VERSION, (uint8_t*) &params, sizeof(params));
+}
+
+void inline sendPhysPttState(bool isPhysPttDown) {
+  __sendCmdToHost(isPhysPttDown ? COMMAND_PHYS_PTT_DOWN : COMMAND_PHYS_PTT_UP);
+}
+
+void inline sendAudio(const byte *data, size_t len) {
+  __sendCmdToHost(COMMAND_RX_AUDIO, data, len);
 }

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/protocol.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/protocol.h
@@ -14,20 +14,20 @@ const uint8_t COMMAND_PTT_UP           = 2;  // stop transmitting audio, go into
 const uint8_t COMMAND_TUNE_TO          = 3;  // change the frequency
 const uint8_t COMMAND_FILTERS          = 4;  // toggle filters on/off
 const uint8_t COMMAND_STOP             = 5;  // stop everything, just wait for next command
-const uint8_t COMMAND_GET_FIRMWARE_VER = 6;  // report FIRMWARE_VER in the format '00000001' for 1 (etc.)
+const uint8_t COMMAND_GET_FIRMWARE_VER = 6;  // reply with [COMMAND_VERSION(Version)]
 
 // Outgoing commands (ESP32 -> Android)
-const uint8_t COMMAND_SMETER_REPORT  = 0x53; // 'S'
-const uint8_t COMMAND_PHYS_PTT_DOWN  = 0x44; // 'D'
-const uint8_t COMMAND_PHYS_PTT_UP    = 0x55; // 'U'
-const uint8_t COMMAND_DEBUG_INFO     = 0x01;
-const uint8_t COMMAND_DEBUG_ERROR    = 0x02;
-const uint8_t COMMAND_DEBUG_WARN     = 0x03;
-const uint8_t COMMAND_DEBUG_DEBUG    = 0x04;
-const uint8_t COMMAND_DEBUG_TRACE    = 0x05;
-const uint8_t COMMAND_HELLO          = 0x06;
-const uint8_t COMMAND_RX_AUDIO       = 0x07;
-const uint8_t COMMAND_VERSION        = 0x08;
+const uint8_t COMMAND_SMETER_REPORT  = 0x53; // [COMMAND_SMETER_REPORT(Rssi)]
+const uint8_t COMMAND_PHYS_PTT_DOWN  = 0x44; // [COMMAND_PHYS_PTT_DOWN()]
+const uint8_t COMMAND_PHYS_PTT_UP    = 0x55; // [COMMAND_PHYS_PTT_UP()]
+const uint8_t COMMAND_DEBUG_INFO     = 0x01; // [COMMAND_DEBUG_INFO(char[])]
+const uint8_t COMMAND_DEBUG_ERROR    = 0x02; // [COMMAND_DEBUG_ERROR(char[])]
+const uint8_t COMMAND_DEBUG_WARN     = 0x03; // [COMMAND_DEBUG_WARN(char[])]
+const uint8_t COMMAND_DEBUG_DEBUG    = 0x04; // [COMMAND_DEBUG_DEBUG(char[])]
+const uint8_t COMMAND_DEBUG_TRACE    = 0x05; // [COMMAND_DEBUG_TRACE(char[])]
+const uint8_t COMMAND_HELLO          = 0x06; // [COMMAND_HELLO()]
+const uint8_t COMMAND_RX_AUDIO       = 0x07; // [COMMAND_RX_AUDIO(int8_t[])]
+const uint8_t COMMAND_VERSION        = 0x08; // [COMMAND_VERSION(Version)]
 
 // COMMAND_VERSION parameters
 struct version {

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/protocol.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/protocol.h
@@ -32,6 +32,7 @@ const byte COMMAND_VERSION        = 0x08;
 struct version {
     uint16_t    ver;
     char        radioModuleStatus;
+    hw_ver_t    hw;
 } __attribute__((__packed__));
   
 typedef struct version Version;

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/protocol.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/protocol.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <Arduino.h>
+#include "globals.h"
+#include "debug.h"
+
+// Delimeter must also match Android app
+#define DELIMITER_LENGTH 8
+const uint8_t COMMAND_DELIMITER[DELIMITER_LENGTH] = {0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF};
+
+// Commands defined here must match the Android app
+const uint8_t COMMAND_PTT_DOWN         = 1;  // start transmitting audio that Android app will send
+const uint8_t COMMAND_PTT_UP           = 2;  // stop transmitting audio, go into RX mode
+const uint8_t COMMAND_TUNE_TO          = 3;  // change the frequency
+const uint8_t COMMAND_FILTERS          = 4;  // toggle filters on/off
+const uint8_t COMMAND_STOP             = 5;  // stop everything, just wait for next command
+const uint8_t COMMAND_GET_FIRMWARE_VER = 6;  // report FIRMWARE_VER in the format '00000001' for 1 (etc.)
+
+// Outgoing commands (ESP32 -> Android)
+const byte COMMAND_SMETER_REPORT  = 0x53; // 'S'
+const byte COMMAND_PHYS_PTT_DOWN  = 0x44; // 'D'
+const byte COMMAND_PHYS_PTT_UP    = 0x55; // 'U'
+const byte COMMAND_DEBUG_INFO     = 0x01;
+const byte COMMAND_DEBUG_ERROR    = 0x02;
+const byte COMMAND_DEBUG_WARN     = 0x03;
+const byte COMMAND_DEBUG_DEBUG    = 0x04;
+const byte COMMAND_DEBUG_TRACE    = 0x05;
+const byte COMMAND_HELLO          = 0x06;
+const byte COMMAND_RX_AUDIO       = 0x07;
+const byte COMMAND_VERSION        = 0x08;
+
+struct version {
+    uint16_t    ver;
+    char        radioModuleStatus;
+} __attribute__((__packed__));
+  
+typedef struct version Version;

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/protocol.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/protocol.h
@@ -49,7 +49,7 @@ typedef struct rssi Rssi;
  * Send a command with params
  * Format: [DELIMITER(8 bytes)] [CMD(1 byte)] [paramLen(1 byte)] [param data(N bytes)]
  */
-void sendCmdToAndroid(Esp32ToHost cmd, const byte *params, size_t paramsLen) {
+void sendCmdToHost(Esp32ToHost cmd, const byte *params, size_t paramsLen) {
   // Safety check: limit paramsLen to 255 for 1-byte length
   if (paramsLen > 255) {
     paramsLen = 255;  // or handle differently (split, or error, etc.)
@@ -67,6 +67,6 @@ void sendCmdToAndroid(Esp32ToHost cmd, const byte *params, size_t paramsLen) {
   }
 }
 
-void inline sendCmdToAndroid(Esp32ToHost cmd) {
-  sendCmdToAndroid(cmd, NULL, 0);
+void inline sendCmdToHost(Esp32ToHost cmd) {
+  sendCmdToHost(cmd, NULL, 0);
 }

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/protocol.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/protocol.h
@@ -41,7 +41,7 @@ typedef struct version Version;
 
 // COMMAND_SMETER_REPORT parameters
 struct rssi {
-  uint8_t     val;
+  uint8_t     rssi;
 } __attribute__((__packed__));
 typedef struct rssi Rssi;
 
@@ -77,7 +77,7 @@ void inline sendHello() {
 
 void inline sendRssi(uint8_t rssi) {
   Rssi params = {
-    .val = rssi
+    .rssi = rssi
   };
   __sendCmdToHost(COMMAND_SMETER_REPORT, (uint8_t*) &params, sizeof(params));
 }


### PR DESCRIPTION

This PR introduces two key changes:

1. **Wraps Audio Stream into a Frame**: Audio data is now encapsulated into frames, streamlining the data structure.
2. **Adheres to Standard Protocol for GET_VERSION Reply**: The GET_VERSION response now follows the standard protocol format: `[DELIMITER(8 bytes)] [CMD(1 byte)] [paramLen(1 byte)] [param data(N bytes)]`.

With these changes, the protocol is unified in one direction, simplifying the parser by eliminating the need for the lookahead buffer. If this PR is accepted, I will proceed with converting the "Host to ESP32" stream to align with this protocol as well.