### PR TITLE
Fixed race condition

### DIFF
--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
@@ -94,7 +94,6 @@ import org.apache.commons.lang3.ArrayUtils;
 import java.io.IOException;
 import java.security.SecureRandom;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -143,7 +142,6 @@ public class RadioAudioService extends Service {
     private SerialInputOutputManager usbIoManager;
     private Protocol.Sender hostToEsp32;
     private Map<String, Integer> mTones = new HashMap<>();
-    private static final int MS_FOR_FINAL_TX_AUDIO_BEFORE_PTT_UP = 400;
 
     // For receiving audio from ESP32 / radio
     private AudioTrack audioTrack;

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
@@ -142,7 +142,6 @@ public class RadioAudioService extends Service {
     private static UsbSerialPort serialPort;
     private SerialInputOutputManager usbIoManager;
     private Protocol.Sender hostToEsp32;
-    private static final int TX_AUDIO_CHUNK_SIZE = Protocol.PROTO_MTU; // Tx audio bytes to send to ESP32 in a single USB write
     private Map<String, Integer> mTones = new HashMap<>();
     private static final int MS_FOR_FINAL_TX_AUDIO_BEFORE_PTT_UP = 400;
 
@@ -820,18 +819,9 @@ public class RadioAudioService extends Service {
             return;
         }
         setMode(MODE_RX);
-
-        // Hold off on telling the ESP32 firmware to PTT_UP, because we want the last bit of
-        // tx audio to be transmitted first (it's stuck in buffers).
-        final Handler handler = new Handler(Looper.getMainLooper());
-        handler.postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                hostToEsp32.pttUp();
-                audioTrack.flush();
-                callbacks.txEnded();
-            }
-        }, MS_FOR_FINAL_TX_AUDIO_BEFORE_PTT_UP);
+        hostToEsp32.pttUp();
+        audioTrack.flush();
+        Optional.ofNullable(callbacks).ifPresent(RadioAudioServiceCallbacks::txEnded);
     }
 
     public void reconnectViaUSB() {
@@ -1164,45 +1154,9 @@ public class RadioAudioService extends Service {
         if (!dataMode) {
             audioBuffer = applyMicGain(audioBuffer);
         }
-
-        if (audioBuffer.length <= TX_AUDIO_CHUNK_SIZE) {
-            hostToEsp32.txAudio(audioBuffer);
-        } else {
-            // If the audio is fairly long, we need to send it to ESP32 at the same rate
-            // as audio sampling. Otherwise, we'll overwhelm its DAC buffer and some audio will
-            // be lost.
-            final Handler handler = new Handler(Looper.getMainLooper());
-            final float msToSendOneChunk = (float) TX_AUDIO_CHUNK_SIZE / (float) AUDIO_SAMPLE_RATE * 1000f;
-            float nextSendDelay = 0f;
-            byte[] finalAudioBuffer = audioBuffer;
-            for (int i = 0; i < audioBuffer.length; i += TX_AUDIO_CHUNK_SIZE) {
-                final int chunkStart = i;
-                handler.postDelayed(new Runnable() {
-                    @Override
-                    public void run() {
-                        android.os.Process.setThreadPriority(
-                            android.os.Process.THREAD_PRIORITY_BACKGROUND +
-                                android.os.Process.THREAD_PRIORITY_MORE_FAVORABLE);
-                        hostToEsp32.txAudio(Arrays.copyOfRange(finalAudioBuffer, chunkStart,
-                            Math.min(finalAudioBuffer.length, chunkStart + TX_AUDIO_CHUNK_SIZE)));
-                    }
-                }, (int) nextSendDelay);
-
-                nextSendDelay += msToSendOneChunk;
-            }
-
-            // In data mode, also schedule PTT up after last audio chunk goes out.
-            if (dataMode) {
-                handler.postDelayed(new Runnable() {
-                    @Override
-                    public void run() {
-                        android.os.Process.setThreadPriority(
-                            android.os.Process.THREAD_PRIORITY_BACKGROUND +
-                                android.os.Process.THREAD_PRIORITY_MORE_FAVORABLE);
-                        endPtt();
-                    }
-                }, (int) nextSendDelay);
-            }
+        hostToEsp32.txAudio(audioBuffer);
+        if (dataMode) {
+            endPtt();
         }
     }
 

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/debug.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/debug.h
@@ -86,8 +86,44 @@ int debug_log_printf(SndCommand cmd, const char* format, ...) {
 }
 
 void printEnvironment() {
-#ifndef RELEASE 
+#ifndef RELEASE
+  esp_reset_reason_t reset_reason = esp_reset_reason();
   _LOGI("---");
+  switch (reset_reason) {
+    case ESP_RST_POWERON:
+      _LOGI("Reset Reason: Power On Reset");
+      break;
+    case ESP_RST_EXT:
+      _LOGI("Reset Reason: External Pin Reset");
+      break;
+    case ESP_RST_SW:
+      _LOGI("Reset Reason: Software Reset");
+      break;
+    case ESP_RST_PANIC:
+      _LOGI("Reset Reason: Exception/Panic Reset");
+      break;
+    case ESP_RST_INT_WDT:
+      _LOGI("Reset Reason: Interrupt Watchdog Reset");
+      break;
+    case ESP_RST_TASK_WDT:
+      _LOGI("Reset Reason: Task Watchdog Reset");
+      break;
+    case ESP_RST_WDT:
+      _LOGI("Reset Reason: Other Watchdog Reset");
+      break;
+    case ESP_RST_DEEPSLEEP:
+      _LOGI("Reset Reason: Deep Sleep Reset");
+      break;
+    case ESP_RST_BROWNOUT:
+      _LOGI("Reset Reason: Brownout Reset");
+      break;
+    case ESP_RST_SDIO:
+      _LOGI("Reset Reason: SDIO Reset");
+      break;
+    default:
+      _LOGI("Reset Reason: Unknown");
+      break;
+  }
   _LOGI("Heap Size: %d", ESP.getHeapSize());
   _LOGI("SDK Version: %s", ESP.getSdkVersion());
   _LOGI("CPU Freq: %d", ESP.getCpuFreqMHz());

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/debug.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/debug.h
@@ -137,6 +137,14 @@ void printEnvironment() {
 #endif  
 }
 
+#ifndef RELEASE
+extern "C" void _esp_error_check_failed(esp_err_t rc, const char *file, int line, const char *function, const char *expression){
+  debug_log_printf(COMMAND_DEBUG_ERROR, "[%6u][E][%s:%u]: %s ==> %s", (unsigned long) (esp_timer_get_time() / 1000ULL), file, line, expression, esp_err_to_name(rc));
+  debug_log_printf(COMMAND_DEBUG_ERROR, "[%6u][E][%s:%u]: ESP_ERROR_CHECK failed! Halting.", (unsigned long) (esp_timer_get_time() / 1000ULL), file, line);
+  while (true);
+}
+#endif 
+
 void measureLoopFrequency() {
 #ifndef RELEASE
   // Exponential Weighted Moving Average (EWMA) for loop time

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
@@ -42,6 +42,9 @@ const char RADIO_MODULE_FOUND     = 'f';
 char radioModuleStatus            = RADIO_MODULE_NOT_FOUND;
 
 void setMode(Mode newMode) {
+  if (mode == newMode) {
+    return;
+  }
   mode = newMode;
   switch (mode) {
     case MODE_STOPPED:
@@ -194,8 +197,10 @@ void handleCommands(RcvCommand command, uint8_t *params, size_t param_len) {
       esp_task_wdt_reset();
       break;
     case COMMAND_HOST_TX_AUDIO:
-      processTxAudio(params, param_len);
-      esp_task_wdt_reset();
+      if (mode == MODE_TX) {
+        processTxAudio(params, param_len);
+        esp_task_wdt_reset();
+      }
       break;                              
   }
 }


### PR DESCRIPTION
 Ignore COMMAND_HOST_TX_AUDIO when the mode is not TX. Added reset reason to the log.

Also removed async processing:
1. Delayed audio transmission is no longer needed; data is pushed directly to the buffer.
2. Delayed PttUp, likely introduced due to (1), is now unnecessary as everything is correctly ordered within the buffer.

Log failed "ESP_ERROR_CHECK"