### PR TITLE
Refactor SQ_PIN and ADC_ATTENUATION handling.

### DIFF
--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/globals.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/globals.h
@@ -40,7 +40,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define ADC_PIN       34  // If this is changed, you may need to manually edit adc1_config_channel_atten() below too.
 #define PTT_PIN       18  // Keys up the radio module
 #define PD_PIN        19
-uint8_t SQ_PIN      = 32;
+#define SQ_PIN_HW1    32  // 
+#define SQ_PIN_HW2     4  // Squelch pin. In v2.0c, this is GPIO 4. In v1.x and v2.0d, this is GPIO 32.
 #define PHYS_PTT_PIN1 5   // Optional. Buttons may be attached to either or both of this and next pin. They behave the same.
 #define PHYS_PTT_PIN2 33  // Optional. See above.
 
@@ -72,3 +73,6 @@ bool squelched = false;
 
 // Forward declarations
 void setMode(Mode newMode);
+
+// Squelch pin
+uint8_t sqPin = SQ_PIN_HW1;

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/globals.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/globals.h
@@ -45,8 +45,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define PHYS_PTT_PIN1 5   // Optional. Buttons may be attached to either or both of this and next pin. They behave the same.
 #define PHYS_PTT_PIN2 33  // Optional. See above.
 
-#define ADC_BIAS_VOLTAGE  1.75
-#define ADC_ATTENUATION   ADC_ATTEN_DB_12
+#define ADC_BIAS_VOLTAGE     1.75
+#define ADC_ATTENUATION      ADC_ATTEN_DB_12
+#define ADC_ATTENUATION_v20C ADC_ATTEN_DB_0  // v2.0c has a lower input ADC range
 
 // Hardware version detection
 #define HW_VER_PIN_0  39  // 0xF0

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
@@ -95,15 +95,15 @@ void setup() {
   switch (hardware_version) {
     case HW_VER_V1:
       COLOR_HW_VER = {0, 32, 0};
-      SQ_PIN = 32;
+      sqPin = SQ_PIN_HW1;
       break;
     case HW_VER_V2_0C:
       COLOR_HW_VER = {32, 0, 0};
-      SQ_PIN = 4;
+      sqPin = SQ_PIN_HW2;
       break;
     case HW_VER_V2_0D:
       COLOR_HW_VER = {0, 0, 32};
-      SQ_PIN = 4;
+      sqPin = SQ_PIN_HW2;
       break;
     default:
       // Unknown version detected. Indicate this some way?
@@ -117,7 +117,7 @@ void setup() {
   // Set up radio module defaults
   pinMode(PD_PIN, OUTPUT);
   digitalWrite(PD_PIN, HIGH);  // Power on
-  pinMode(SQ_PIN, INPUT);
+  pinMode(sqPin, INPUT);
   pinMode(PTT_PIN, OUTPUT);
   digitalWrite(PTT_PIN, HIGH);  // Rx
   // Communication with DRA818V radio module via GPIO pins
@@ -126,7 +126,7 @@ void setup() {
   //
   debugSetup();
   // Begin in STOPPED mode
-  squelched = (digitalRead(SQ_PIN) == HIGH);
+  squelched = (digitalRead(sqPin) == HIGH);
   setMode(MODE_STOPPED);
   ledSetup();
   sendHello();
@@ -234,7 +234,7 @@ void rssiLoop() {
 }
 
 void loop() {
-  squelched = squelchDebounce.debounce((digitalRead(SQ_PIN) == HIGH));
+  squelched = squelchDebounce.debounce((digitalRead(sqPin) == HIGH));
   debugLoop();
   ledLoop();
   protocolLoop();

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/rxAudio.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/rxAudio.h
@@ -83,7 +83,7 @@ inline void injectADCBias() {
 
 inline void setUpADCAttenuator() {
   if (hardware_version == HW_VER_V2_0C) { // v2.0c has a lower input ADC range
-    adc1_config_channel_atten(I2S_ADC_CHANNEL, ADC_ATTEN_DB_0);
+    adc1_config_channel_atten(I2S_ADC_CHANNEL, ADC_ATTENUATION_v20C);
   } else {
     adc1_config_channel_atten(I2S_ADC_CHANNEL, ADC_ATTENUATION);
   }


### PR DESCRIPTION
* Renamed SQ pin variable to match code style conventions
* Centralized pin definitions for better maintainability
* Centralized ADC attenuator definitions for better maintainability