### PR TITLE
 Cleanup: Make static analyzers less annoying

### DIFF
--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/aprs/parser/APRSPacket.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/aprs/parser/APRSPacket.java
@@ -20,244 +20,170 @@
  */
 package com.vagell.kv4pht.aprs.parser;
 
+import lombok.Getter;
+import lombok.Setter;
+import org.jetbrains.annotations.NotNull;
+
 import java.io.ByteArrayOutputStream;
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 /**
- * 
  * @author johng
- *  This class represents a complete APRS AX.25 packet, as found in a TNC2-style string:
- *  SOURCE>DESTIN,VIA,VIA:payload
+ * This class represents a complete APRS AX.25 packet, as found in a TNC2-style string:
+ * SOURCE>DESTIN,VIA,VIA:payload
  */
 public class APRSPacket implements Serializable {
-    private static final long serialVersionUID = 1L;
-	private Date receivedTimestamp = null;
+
+	public static final Set<String> Q_CONSTRUCTS = Set.of("qar", "qas", "qac", "qao");
+	private static final long serialVersionUID = 1L;
+
+    @Getter
+    private final Date receivedTimestamp;
+
+    @Getter
+    @Setter
     private String originalString;
-	private String sourceCall;
-    private String destinationCall;
-    private ArrayList<Digipeater> digipeaters;
-    private char dti;
-    private InformationField aprsInformation;
+
+    private final List<Digipeater> digipeaters;
+
+    @Getter
+    private final String sourceCall;
+
+    @Getter
+    private final String destinationCall;
+
+    @Getter
+    private final char dti;
+
+    @Getter
+    private final InformationField payload;
+
+    @Setter
     private boolean hasFault;
-	private String comment;
+
+    private String comment;
 
     static final String REGEX_PATH_ALIASES = "^(WIDE|TRACE|RELAY)\\d*$";
-    
-    public APRSPacket( String source, String destination, ArrayList<Digipeater> digipeaters, byte[] body) {
-		receivedTimestamp = new Date(System.currentTimeMillis());
-        this.sourceCall=source.toUpperCase();
-        this.destinationCall=destination.toUpperCase();
-        if ( digipeaters == null ) {
-        	Digipeater aprsIs = new Digipeater("TCPIP*");
-        	this.digipeaters = new ArrayList<Digipeater>();
-        	this.digipeaters.add(aprsIs);
+
+    public APRSPacket(String source, String destination, List<Digipeater> digipeaters, byte[] payload) {
+        receivedTimestamp = new Date(System.currentTimeMillis());
+        this.sourceCall = source.toUpperCase();
+        this.destinationCall = destination.toUpperCase();
+		this.digipeaters = Optional.ofNullable(digipeaters).orElse(List.of(new Digipeater("TCPIP*")));
+        this.dti = (char) payload[0];
+        this.payload = new InformationField(payload);
+    }
+
+    public static String getBaseCall(String callsign) {
+        int sepIdx = callsign.indexOf('-');
+        if (sepIdx > -1) {
+            return callsign.substring(0, sepIdx);
         } else {
-        	this.digipeaters = digipeaters;
+            return callsign;
         }
-		this.dti = (char)body[0];
-        this.aprsInformation = new InformationField(body);
-    }
-    
-    
-	/** 
-	 * @param callsign
-	 * @return String
-	 */
-	public static final String getBaseCall(String callsign) {
-    	int sepIdx = callsign.indexOf('-');
-    	if ( sepIdx > -1 ) {
-    		return callsign.substring(0,sepIdx);
-    	} else {
-    		return callsign;
-    	}
-    }
-    
-    
-	/** 
-	 * @param callsign
-	 * @return String
-	 */
-	public static final String getSsid(String callsign) {
-    	int sepIdx = callsign.indexOf('-');
-    	if ( sepIdx > -1 ) {
-    		return callsign.substring(sepIdx+1);
-    	} else {
-    		return "0";
-    	}
-    }
-    
-    public String getIgate() {
-    	for ( int i=0; i<digipeaters.size(); i++) {
-    		Digipeater d = digipeaters.get(i);
-    		// I'm not sure I'm treating these correctly (poor understanding of the
-    		// Q-constructs on my part).  For now, I'm saying that call sign AFTER a 
-    		// q-construct is the I-gate.
-    		if ( d.getCallsign().equalsIgnoreCase("qar") && i<digipeaters.size()-1 ) {
-    			return digipeaters.get(i+1).toString();
-    		}
-    		if ( d.getCallsign().equalsIgnoreCase("qas") && i<digipeaters.size()-1 ) {
-    			return digipeaters.get(i+1).toString();
-    		}
-    		if ( d.getCallsign().equalsIgnoreCase("qac") && i<digipeaters.size()-1 ) {
-    			return digipeaters.get(i+1).toString();
-    		}
-    		if ( d.getCallsign().equalsIgnoreCase("qao") && i<digipeaters.size()-1 ) {
-    			return digipeaters.get(i+1).toString();
-    		}
-    	}
-    	return "";
     }
 
-    /**
-     * @return the source
-     */
-    public String getSourceCall() {
-        return sourceCall;
+    public static String getSsid(String callsign) {
+        int sepIdx = callsign.indexOf('-');
+        if (sepIdx > -1) {
+            return callsign.substring(sepIdx + 1);
+        } else {
+            return "0";
+        }
     }
 
-    /**
-     * @return the destination
-     */
-    public String getDestinationCall() {
-        return destinationCall;
-    }
+	public String getIgate() {
+		// I'm not sure if I'm treating these correctly (poor understanding of the
+		// Q-constructs on my part).  For now, I'm saying that call sign AFTER a
+		// q-construct is the I-gate.
+		for (int i = 0; i < digipeaters.size() - 1; i++) {
+            if (Q_CONSTRUCTS.contains(digipeaters.get(i).getCallsign().toLowerCase())) {
+				return digipeaters.get(i + 1).toString();
+			}
+		}
+		return "";
+	}
 
-    /**
-     * @return the digipeaters
-     */
-    public ArrayList<Digipeater> getDigipeaters() {
-        return digipeaters;
-    }
-    
-    public void setDigipeaters(ArrayList<Digipeater> newDigis) {
-	    digipeaters = newDigis;
-    }
-
-    /**
+	/**
      * @return the last digipeater in the path marked as used (with '*') or null.
      */
     public String getLastUsedDigi() {
-        for (int i=digipeaters.size()-1; i>=0; i--) {
-            Digipeater d = digipeaters.get(i);
-	    String call = d.getCallsign();
-            if (d.isUsed() && !call.matches(REGEX_PATH_ALIASES))
-                return call;
-        }
-        return null;
+        return IntStream.range(0, digipeaters.size())
+            .mapToObj(i -> digipeaters.get(digipeaters.size() - 1 - i))
+            .filter(d -> d.isUsed() && !d.getCallsign().matches(REGEX_PATH_ALIASES))
+            .map(Digipeater::getCallsign)
+            .findFirst()
+            .orElse(null);
     }
 
     public String getDigiString() {
-        StringBuilder sb = new StringBuilder();
-		boolean first=true;
-        for ( Digipeater digi : digipeaters ) {
-			if ( first ) {
-            	sb.append(digi.toString());
-				first=false;
-			} else 
-				sb.append(","+digi.toString());
-        }
-        return sb.toString();
+        return digipeaters.stream()
+            .map(Digipeater::toString)
+            .collect(Collectors.joining(","));
     }
 
-    /**
-     * @return the dti
-     */
-    public char getDti() {
-        return dti;
-    }
-
-    /**
-     * @return the aprsInformation
-     */
-    public InformationField getAprsInformation() {
-        return aprsInformation;
-    }
     public boolean isAprs() {
-    	return true;
+        return true;
     }
 
-	/**
-	 * @return the hasFault
-	 */
-	public boolean hasFault() {
-		return ( this.hasFault | aprsInformation.hasFault() );
-	}
+    /**
+     * @return the hasFault
+     */
+    public boolean hasFault() {
+        return (this.hasFault | payload.hasFault());
+    }
 
-	/**
-	 * @param hasFault the hasFault to set
-	 */
-	public void setHasFault(boolean hasFault) {
-		this.hasFault = hasFault;
-	}
+    public final void setComment(String comment) {
+        this.comment = comment;
+    }
 
-	/**
-	 * @return the originalString
-	 */
-	public final String getOriginalString() {
-		return originalString;
-	}
+    public final String getComment() {
+        return this.comment;
+    }
 
-	/**
-	 * @param originalString the originalString to set
-	 */
-	public final void setOriginalString(String originalString) {
-		this.originalString = originalString;
-	}
-
-		public void setInfoField(InformationField infoField) {
-		this.aprsInformation = infoField;
-	}
-
-	public final void setComment(String comment) {
-		this.comment = comment;
-	}
-
-	public final String getComment() {
-		return this.comment;
-	}
-
-	@Override
-	public String toString() {
-		StringBuffer sb = new StringBuffer("-------------------------------\n");
-		sb.append(sourceCall+">"+destinationCall+"\n");
-		sb.append("Via Digis: "+getDigiString()+"\n");
-		sb.append(aprsInformation.toString());
-		return sb.toString();
-	}
+    @Override
+    public @NotNull String toString() {
+        return String.format(
+            "-------------------------------\n%s>%s\nVia Digis: %s\n%s",
+            sourceCall,
+            destinationCall,
+            getDigiString(),
+			payload
+        );
+    }
 
 	public byte[] toAX25Frame() throws IllegalArgumentException {
-		ByteArrayOutputStream baos = new ByteArrayOutputStream();
-		// write AX.25 header
-		// dest
+		ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+		// Destination address (with * to mark end of first address)
 		byte[] dest = new Digipeater(destinationCall + "*").toAX25();
-		baos.write(dest, 0, dest.length);
-		// src
+		byteArrayOutputStream.write(dest, 0, dest.length);
+		// Source address
 		byte[] src = new Digipeater(sourceCall).toAX25();
-		// last byte of last address is |=1
-		if (digipeaters.size() == 0)
-			src[6] |= 1;
-		baos.write(src, 0, src.length);
-		// digipeater list
-		for (int i = 0; i < digipeaters.size(); i++) {
-			byte[] d = digipeaters.get(i).toAX25();
-			// last byte of last digi is |=1
-			if (i == digipeaters.size() - 1)
-				d[6] |= 1;
-			baos.write(d, 0, 7);
+		if (digipeaters.isEmpty()) {
+			src[6] |= 0x01; // Mark as last address if no digipeaters
 		}
-		// control: UI-frame, poll-bit set
-		baos.write(0x03);
-		// pid: 0xF0 - no layer 3 protocol
-		baos.write(0xF0);
-		// write content
-		byte[] content = aprsInformation.getRawBytes();
-		baos.write(content, 0, content.length);
-		return baos.toByteArray();
-	}
-
-	public Date getRecevedTimestamp() {
-		return this.receivedTimestamp;
+		byteArrayOutputStream.write(src, 0, src.length);
+		// Digipeater path
+		for (int i = 0; i < digipeaters.size(); i++) {
+			byte[] digi = digipeaters.get(i).toAX25();
+			if (i == digipeaters.size() - 1) {
+				digi[6] |= 0x01; // Mark last digipeater
+			}
+			byteArrayOutputStream.write(digi, 0, 7); // AX.25 address is always 7 bytes
+		}
+		// Control (0x03 = UI-frame), PID (0xF0 = no layer 3 protocol)
+		byteArrayOutputStream.write(0x03);
+		byteArrayOutputStream.write(0xF0);
+		// Payload
+		byte[] payload = this.payload.getRawBytes();
+		byteArrayOutputStream.write(payload, 0, payload.length);
+		return byteArrayOutputStream.toByteArray();
 	}
 }
 

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/aprs/parser/APRSPacket.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/aprs/parser/APRSPacket.java
@@ -136,7 +136,7 @@ public class APRSPacket implements Serializable {
      * @return the hasFault
      */
     public boolean hasFault() {
-        return (this.hasFault | payload.hasFault());
+        return (this.hasFault || payload.hasFault());
     }
 
     public final void setComment(String comment) {

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/aprs/parser/Parser.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/aprs/parser/Parser.java
@@ -52,7 +52,7 @@ public class Parser {
 				System.out.println("Via:	"+packet.getDigiString());
 				System.out.println("DTI:	"+packet.getDti());
 				System.out.println("Valid:	"+packet.isAprs());
-				InformationField data = packet.getAprsInformation();
+				InformationField data = packet.getPayload();
 				System.out.println("Data:	" + data);
 				if ( packet.isAprs() && data != null) {
 					System.out.println("    Type:	" + data.getClass().getName());
@@ -148,7 +148,7 @@ public class Parser {
 			packet.setComment("Invalid DTI");
 			return packet;
 		}
-		InformationField infoField = packet.getAprsInformation();
+		InformationField infoField = packet.getPayload();
 		int cursor = 0;
         switch ( dti ) {
         	case '/':

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/firmware/FirmwareUtils.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/firmware/FirmwareUtils.java
@@ -113,10 +113,18 @@ public final class FirmwareUtils {
         return new SerialTransport() {
             @Override
             public int read(byte[] buffer, int length) throws IOException {
+                if (Thread.currentThread().isInterrupted()) {
+                    Log.w(TAG, "Read operation interrupted, terminating.");
+                    throw new IOException("Read operation interrupted");
+                }
                 return usbSerialPort.read(buffer, length, 100);
             }
             @Override
             public void write(byte[] buffer, int length) throws IOException {
+                if (Thread.currentThread().isInterrupted()) {
+                    Log.w(TAG, "Write operation interrupted, terminating.");
+                    throw new IOException("Write operation interrupted");
+                }
                 usbSerialPort.write(buffer, length, 0);
             }
             @Override

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/javAX25/ax25/Afsk1200Demodulator.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/javAX25/ax25/Afsk1200Demodulator.java
@@ -98,7 +98,7 @@ private float[] td_filter;
 		this(sample_rate,filter_length,6,null);
 	}
 
-  public Afsk1200Demodulator(int sample_rate, int filter_length, int emphasis, PacketHandler h) throws Exception {
+  public Afsk1200Demodulator(int sample_rate, int filter_length, int emphasis, PacketHandler h) {
   	super(sample_rate==8000 ? 16000 : sample_rate);
   	
   	if (sample_rate==8000) {
@@ -112,7 +112,7 @@ private float[] td_filter;
 	  	if (Afsk1200Filters.sample_rates[rate_index] == sample_rate) break;
 	  }
 		if (rate_index == Afsk1200Filters.sample_rates.length) {
-			throw new Exception("Sample rate "+sample_rate+" not supported");
+			throw new RuntimeException("Sample rate "+sample_rate+" not supported");
 		}
 			
 		handler = h;

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/javAX25/ax25/Afsk1200MultiDemodulator.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/javAX25/ax25/Afsk1200MultiDemodulator.java
@@ -91,7 +91,7 @@ public class Afsk1200MultiDemodulator extends PacketDemodulator {
 	//private int sample_rate;
 	//private int max_sample_delay;
 
-	public Afsk1200MultiDemodulator(int sample_rate, PacketHandler h) throws Exception {
+	public Afsk1200MultiDemodulator(int sample_rate, PacketHandler h)  {
   	super(sample_rate);
 		//this.sample_rate = sample_rate;
 		this.h = h;

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/javAX25/ax25/PacketHandler.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/javAX25/ax25/PacketHandler.java
@@ -20,5 +20,5 @@
 package com.vagell.kv4pht.javAX25.ax25;
 
 public interface PacketHandler {
-	public void handlePacket(byte[] packet);
+	void handlePacket(byte[] packet);
 }

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/MicGainBoost.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/MicGainBoost.java
@@ -1,0 +1,28 @@
+package com.vagell.kv4pht.radio;
+
+import lombok.Getter;
+
+public enum MicGainBoost {
+    NONE(1.0f, "None"),
+    LOW(1.5f, "Low"),
+    MED(2.0f, "Med"),
+    HIGH(2.5f, "High");
+
+    @Getter
+    private final float gain;
+    private final String label;
+
+    MicGainBoost(float gain, String label) {
+        this.gain = gain;
+        this.label = label;
+    }
+
+    public static MicGainBoost parse(String str) {
+        for (MicGainBoost value : values()) {
+            if (value.label.equalsIgnoreCase(str)) {
+                return value;
+            }
+        }
+        return NONE;
+    }
+}

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/Protocol.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/Protocol.java
@@ -361,6 +361,9 @@ public final class Protocol {
                     processCommand();
                     resetParser();
                 }
+                if (commandParamLen > commandParams.length) {
+                    resetParser();
+                }
             } else {
                 if (paramIndex < commandParamLen) {
                     commandParams[paramIndex++] = b;

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/ProtocolHandshake.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/ProtocolHandshake.java
@@ -67,6 +67,10 @@ class ProtocolHandshake {
             .thenCompose(this::sendConfigStep));
     }
 
+    public void onDestroy() {
+        protocolScheduler.shutdownNow();
+    }
+
     private void startFor(CompletionStage<Void> chain) {
         chain
             .thenCompose(this::waitForFirmwareVersion)

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/ProtocolHandshake.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/ProtocolHandshake.java
@@ -35,6 +35,7 @@ import java.util.concurrent.TimeoutException;
  * Steps include waiting for a HELLO command, sending configuration, and verifying firmware version.
  * This class supports clean chaining with timeouts, and can be restarted if the ESP32 reboots.
  */
+@SuppressWarnings({"javaarchitecture:S7027"})
 class ProtocolHandshake {
     private static final String TAG = ProtocolHandshake.class.getSimpleName();
     private static final int HELLO_TIMEOUT_MS = 1000;

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/ProtocolHandshake.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/ProtocolHandshake.java
@@ -1,0 +1,213 @@
+/*
+kv4p HT (see http://kv4p.com)
+Copyright (C) 2024 Vance Vagell
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package com.vagell.kv4pht.radio;
+
+import android.util.Log;
+import androidx.annotation.NonNull;
+import com.vagell.kv4pht.firmware.FirmwareUtils;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Handles the asynchronous, multistep handshake process with the ESP32 over USB serial.
+ * Steps include waiting for a HELLO command, sending configuration, and verifying firmware version.
+ * This class supports clean chaining with timeouts, and can be restarted if the ESP32 reboots.
+ */
+class ProtocolHandshake {
+    private static final String TAG = ProtocolHandshake.class.getSimpleName();
+    private static final int HELLO_TIMEOUT_MS = 1000;
+    private static final int FIRMWARE_VERSION_TIMEOUT_MS = 60000;
+    private enum HandshakeResult {INVALID, TOO_OLD, OK, RADIO_MODULE_NOT_FOUND}
+    private final RadioAudioService radioAudioService;
+    private final ScheduledExecutorService protocolScheduler = Executors.newSingleThreadScheduledExecutor();
+
+    /**
+     * Future completed when HELLO is received or timeout occurs.
+     */
+    private @NonNull CompletableFuture<Void> waitForHello = CompletableFuture.completedFuture(null);
+    /**
+     * Future completed when firmware version is received or timeout occurs.
+     */
+    private @NonNull CompletableFuture<Optional<Protocol.FirmwareVersion>> waitFirmwareVersion =
+        CompletableFuture.completedFuture(Optional.empty());
+
+    public ProtocolHandshake(RadioAudioService radioAudioService) {
+        this.radioAudioService = radioAudioService;
+    }
+
+    /**
+     * Starts the full handshake process.
+     */
+    public void start() {
+        Log.i(TAG, "Starting protocol handshake with ESP32.");
+        startFor(waitForHello()
+            .thenCompose(this::sendConfigStep));
+    }
+
+    private void startFor(CompletionStage<Void> chain) {
+        chain
+            .thenCompose(this::waitForFirmwareVersion)
+            .thenCompose(this::checkFirmwareVersionAndRadioStatus)
+            .thenAccept(this::handleResult)
+            .exceptionally(ex -> {
+                Log.e(TAG, "Handshake chain failed: " + ex.getMessage());
+                radioAudioService.setMode(RadioMode.BAD_FIRMWARE);
+                radioAudioService.getCallbacks().missingFirmware();
+                return null;
+            });
+    }
+
+    private void handleResult(HandshakeResult res) {
+        switch (res) {
+            case INVALID:
+                Log.e(TAG, "Cannot parse FirmwareVersion packet.");
+                radioAudioService.getCallbacks().missingFirmware();
+                radioAudioService.setMode(RadioMode.BAD_FIRMWARE);
+                return;
+            case TOO_OLD:
+                Log.w(TAG, "Firmware version too old, cannot proceed.");
+                radioAudioService.setMode(RadioMode.BAD_FIRMWARE);
+                return;
+            case RADIO_MODULE_NOT_FOUND:
+                Log.e(TAG, "Radio module not found, cannot proceed.");
+                radioAudioService.setMode(RadioMode.BAD_FIRMWARE);
+                radioAudioService.getCallbacks().radioModuleNotFound();
+                return;
+            case OK:
+                Log.i(TAG, "Firmware version OK, proceeding with radio communication.");
+                radioAudioService.setMode(RadioMode.RX);
+                // Turn off scanning if it was on (e.g. if radio was unplugged briefly and reconnected)
+                radioAudioService.setScanning(false);
+                radioAudioService.getCallbacks().radioConnected();
+        }
+    }
+
+    /**
+     * Called when a HELLO command is received from the ESP32.
+     * If a handshake is already waiting for HELLO, complete it.
+     * If no handshake is active (e.g., due to unexpected reboot), restart the handshake from config step.
+     */
+    public void onHelloReceived() {
+        if (!waitForHello.isDone()) {
+            Log.d(TAG, "HELLO received from ESP32.");
+            waitForHello.complete(null);
+        } else {
+            Log.i(TAG, "ESP32 rebooted, restarting handshake from config step.");
+            startFor(sendConfigStep(null)); // ESP32 rebooted mid-session, restart from config step
+        }
+    }
+
+    /**
+     * Notifies the handshake logic that a firmware version was received from the ESP32.
+     * Completes the waiting future if it's active.
+     *
+     * @param version The firmware version parsed from the received data.
+     * @noinspection OptionalUsedAsFieldOrParameterType
+     */
+    public void onVersionReceived(Optional<Protocol.FirmwareVersion> version) {
+        if (!waitFirmwareVersion.isDone()) {
+            Log.d(TAG, "Firmware version received from ESP32: " + version);
+            waitFirmwareVersion.complete(version);
+        }
+    }
+
+    /**
+     * Waits for the HELLO command from the ESP32 with a timeout.
+     *
+     * @return A future that completes when HELLO is received or times out.
+     */
+    private CompletableFuture<Void> waitForHello() {
+        waitForHello = new CompletableFuture<>();
+        protocolScheduler.schedule(() -> {
+            if (!waitForHello.isDone()) {
+                waitForHello.completeExceptionally(new TimeoutException("Timeout waiting for HELLO"));
+            }
+        }, HELLO_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        return waitForHello;
+    }
+
+    /**
+     * Sends configuration to the ESP32.
+     * Stops any previous communication, notifies callbacks, and sends power config.
+     *
+     * @return A future that completes once the config is sent.
+     */
+    private CompletableFuture<Void> sendConfigStep(Void ignored) {
+        return CompletableFuture.runAsync(() -> {
+            radioAudioService.getCallbacks().radioModuleHandshake();
+            radioAudioService.setMode(RadioMode.STARTUP);
+            radioAudioService.getHostToEsp32().stop();
+            Protocol.Config cfg = Protocol.Config.builder().isHigh(radioAudioService.isHighPower()).build();
+            Log.d(TAG, "Sending configuration to ESP32: " + cfg);
+            radioAudioService.getHostToEsp32().config(cfg);
+        });
+    }
+
+    /**
+     * Waits for a firmware version response from the ESP32 with a timeout.
+     *
+     * @return A future that completes when version is received or times out.
+     */
+    private CompletableFuture<Optional<Protocol.FirmwareVersion>> waitForFirmwareVersion(Void ignored) {
+        waitFirmwareVersion = new CompletableFuture<>();
+        protocolScheduler.schedule(() -> {
+            if (!waitFirmwareVersion.isDone()) {
+                waitFirmwareVersion.completeExceptionally(new TimeoutException("Timeout waiting for firmware version"));
+            }
+        }, FIRMWARE_VERSION_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        return waitFirmwareVersion;
+    }
+
+    /**
+     * Starts communication with the ESP32 after verifying the firmware version.
+     * Updates mode and notifies the app if the firmware is outdated or the radio module is missing.
+     *
+     * @param firmwareVersion The firmware version received from the ESP32.
+     * @return A future that completes when initialization is done.
+     * @noinspection OptionalUsedAsFieldOrParameterType
+     */
+    private CompletableFuture<HandshakeResult> checkFirmwareVersionAndRadioStatus(Optional<Protocol.FirmwareVersion> firmwareVersion) {
+        return CompletableFuture.supplyAsync(() -> {
+            if (!firmwareVersion.isPresent()) {
+                return HandshakeResult.INVALID;
+            }
+            final Protocol.FirmwareVersion ver = firmwareVersion.get();
+            if (ver.getVer() < FirmwareUtils.PACKAGED_FIRMWARE_VER) {
+                radioAudioService.getCallbacks().outdatedFirmware(ver.getVer());
+                return HandshakeResult.TOO_OLD;
+            }
+            radioAudioService.setRadioType(Protocol.RfModuleType.RF_SA818_VHF.equals(ver.getModuleType())
+                ? RadioAudioService.RadioModuleType.VHF
+                : RadioAudioService.RadioModuleType.UHF);
+            radioAudioService.setHasHighLowPowerSwitch(ver.isHasHl());
+            if (Protocol.RadioStatus.RADIO_STATUS_NOT_FOUND.equals(ver.getRadioModuleStatus())) {
+                return HandshakeResult.RADIO_MODULE_NOT_FOUND;
+            } else {
+                radioAudioService.getHostToEsp32().setFlowControlWindow(ver.getWindowSize());
+                return HandshakeResult.OK;
+            }
+        });
+    }
+}

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
@@ -1104,7 +1104,6 @@ public class RadioAudioService extends Service {
             callbacks.chatError("Error in your callsign or recipient callsign.");
             return -1;
         }
-        // TODO: implement retry/ACK timer
         return messageNumber - 1;
     }
 

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
@@ -828,7 +828,7 @@ public class RadioAudioService extends Service implements PacketHandler {
             case COMMAND_SMETER_REPORT:
                 Protocol.Rssi.from(param, len)
                     .map(Protocol.Rssi::getSMeter9Value)
-                    .filter(i -> getMode() == RadioMode.RX || getMode() ==RadioMode.SCAN)
+                    .filter(i -> getMode() == RadioMode.RX || getMode() == RadioMode.SCAN)
                     .ifPresent(callbacks::sMeterUpdate);
                 break;
 

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
@@ -500,7 +500,7 @@ public class RadioAudioService extends Service {
         float deviation = (bandwidth.equals("Wide") ? 0.005f : 0.0025f);
         float offsetMaxFreq = maxHamFreq - deviation;
         float offsetMinFreq = minHamFreq + deviation;
-        txAllowed = !(txFreq < offsetMinFreq) && !(txFreq > offsetMaxFreq);
+        txAllowed = txFreq >= offsetMinFreq && txFreq <= offsetMaxFreq;
     }
 
     private String getTxFreq(String txFreq, int offset, int khz) {

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
@@ -1188,12 +1188,12 @@ public class RadioAudioService extends Service {
         PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
         // Notify the user they got a message.
         NotificationCompat.Builder builder = new NotificationCompat.Builder(this, notificationChannelId)
-                .setSmallIcon(R.drawable.ic_chat_notification)
-                .setContentTitle(title)
-                .setContentText(message)
-                .setContentIntent(pendingIntent)
-                .setAutoCancel(true) // Dismiss on tap
-                .setPriority(NotificationCompat.PRIORITY_DEFAULT);
+            .setSmallIcon(R.drawable.ic_chat_notification)
+            .setContentTitle(title)
+            .setContentText(message)
+            .setContentIntent(pendingIntent)
+            .setAutoCancel(true) // Dismiss on tap
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT);
         NotificationManager notificationManager = getSystemService(NotificationManager.class);
         notificationManager.notify(notificationTypeId, builder.build());
     }

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
@@ -107,6 +107,8 @@ public class RadioAudioService extends Service implements PacketHandler {
     private static final String TAG = RadioAudioService.class.getSimpleName();
     private static final String FIRMWARE_TAG = "firmware";
     private static final int RUNAWAY_TX_TIMEOUT_SEC = 180;
+    // Intents this Activity can handle besides the one that starts it in default mode.
+    public static String INTENT_OPEN_CHAT = "com.vagell.kv4pht.OPEN_CHAT_ACTION";
 
     // === USB Device Matching ===
     private static final int[] ESP32_VENDOR_IDS = {4292, 6790};
@@ -978,7 +980,7 @@ public class RadioAudioService extends Service implements PacketHandler {
                         MESSAGE_NOTIFICATION_TO_YOU_ID,
                         aprsPacket.getSourceCall() + " messaged you",
                         msg.getMessageBody(),
-                        MainActivity.INTENT_OPEN_CHAT);
+                        INTENT_OPEN_CHAT);
                     // Send acknowledgment after a delay
                     handler.postDelayed(() -> sendAckMessage(aprsPacket.getSourceCall().toUpperCase(), msg.getMessageNumber()), 1000);
                 }

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
@@ -378,6 +378,7 @@ public class RadioAudioService extends Service {
     @Override
     public void onDestroy() {
         super.onDestroy();
+        protocolHandshake.onDestroy();
         if (audioTrack != null) {
             audioTrack.stop();
             audioTrack.release();

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
@@ -682,6 +682,7 @@ public class RadioAudioService extends Service {
                 try {
                     serialPort.close();
                 } catch (Exception ignored) {
+                    // Ignore, we don't care if it fails to close.
                 }
                 // Attempt to reconnect after the brief pause above.
                 handler.postDelayed(() -> findESP32Device(), 1000);

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
@@ -1102,7 +1102,8 @@ public class RadioAudioService extends Service {
             Packet ax25Packet = new Packet(aprsPacket.toAX25Frame());
             txAX25Packet(ax25Packet);
         } catch (IllegalArgumentException e) {
-            callbacks.chatError("Error in your callsign or recipient callsign.");
+            Log.e(TAG, "Error: sending APRS packet", e);
+            callbacks.chatError(e.getMessage());
             return -1;
         }
         return messageNumber - 1;

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioMode.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioMode.java
@@ -1,0 +1,11 @@
+package com.vagell.kv4pht.radio;
+
+public enum RadioMode {
+    UNKNOWN,
+    STARTUP,
+    RX,
+    TX,
+    SCAN,
+    BAD_FIRMWARE,
+    FLASHING
+}

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioServiceConnector.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioServiceConnector.java
@@ -1,0 +1,62 @@
+package com.vagell.kv4pht.radio;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.ServiceConnection;
+import android.os.IBinder;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+public class RadioServiceConnector {
+    private RadioAudioService service;
+    private boolean bound = false;
+    private final Context context;
+    private final List<Consumer<RadioAudioService>> callbacks = new ArrayList<>();
+
+    public RadioServiceConnector(Context context) {
+        this.context = context.getApplicationContext();
+    }
+
+    private final ServiceConnection connection = new ServiceConnection() {
+        @Override
+        public void onServiceConnected(ComponentName name, IBinder binder) {
+            RadioAudioService.RadioBinder radioBinder = (RadioAudioService.RadioBinder) binder;
+            service = radioBinder.getService();
+            bound = true;
+            for (Consumer<RadioAudioService> callback : callbacks) {
+                callback.accept(service);
+            }
+            callbacks.clear();
+        }
+
+        @Override
+        public void onServiceDisconnected(ComponentName name) {
+            bound = false;
+            service = null;
+        }
+    };
+
+    public void bind(Consumer<RadioAudioService> onConnected) {
+        bind(new Intent(context, RadioAudioService.class), onConnected);
+    }
+
+    public void bind(Intent intent, Consumer<RadioAudioService> onConnected) {
+        if (bound && service != null) {
+            onConnected.accept(service);
+        } else {
+            callbacks.add(onConnected);
+            context.bindService(intent, connection, Context.BIND_AUTO_CREATE);
+        }
+    }
+
+    public void unbind() {
+        if (bound) {
+            context.unbindService(connection);
+            bound = false;
+        }
+    }
+}
+

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/AddEditMemoryActivity.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/AddEditMemoryActivity.java
@@ -126,9 +126,7 @@ public class AddEditMemoryActivity extends AppCompatActivity {
     @Override
     protected void onStart() {
         super.onStart();
-        serviceConnector.bind(rs -> {
-           this.radioAudioService = rs;
-        });
+        serviceConnector.bind(rs -> this.radioAudioService = rs);
     }
 
     @Override

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/AddEditMemoryActivity.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/AddEditMemoryActivity.java
@@ -126,8 +126,8 @@ public class AddEditMemoryActivity extends AppCompatActivity {
     @Override
     protected void onStart() {
         super.onStart();
-        serviceConnector.bind(radioAudioService -> {
-           this.radioAudioService = radioAudioService;
+        serviceConnector.bind(rs -> {
+           this.radioAudioService = rs;
         });
     }
 

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/AddEditMemoryActivity.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/AddEditMemoryActivity.java
@@ -35,6 +35,7 @@ import com.google.android.material.textfield.TextInputEditText;
 import com.vagell.kv4pht.R;
 import com.vagell.kv4pht.data.ChannelMemory;
 import com.vagell.kv4pht.radio.RadioAudioService;
+import com.vagell.kv4pht.radio.RadioServiceConnector;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -48,11 +49,14 @@ public class AddEditMemoryActivity extends AppCompatActivity {
     private final ThreadPoolExecutor threadPoolExecutor = new ThreadPoolExecutor(2, 2, 0, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>());
     private ChannelMemory mMemory;
     private MainViewModel viewModel;
+    private RadioServiceConnector serviceConnector;
+    private RadioAudioService radioAudioService;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         viewModel = new ViewModelProvider(this).get(MainViewModel.class);
         super.onCreate(savedInstanceState);
+        serviceConnector = new RadioServiceConnector(this);
         setContentView(R.layout.activity_add_edit_memory);
 
         getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
@@ -120,6 +124,14 @@ public class AddEditMemoryActivity extends AppCompatActivity {
     }
 
     @Override
+    protected void onStart() {
+        super.onStart();
+        serviceConnector.bind(radioAudioService -> {
+           this.radioAudioService = radioAudioService;
+        });
+    }
+
+    @Override
     protected void onResume() {
         super.onResume();
         // Put the cursor in the name field by default
@@ -131,6 +143,7 @@ public class AddEditMemoryActivity extends AppCompatActivity {
     protected void onDestroy() {
         super.onDestroy();
         threadPoolExecutor.shutdownNow();
+        serviceConnector.unbind();
     }
 
     private void populateMemoryGroups() {
@@ -286,7 +299,7 @@ public class AddEditMemoryActivity extends AppCompatActivity {
             editFrequencyTextInputEditText.requestFocus();
             return;
         } else {
-            String formattedFrequency = RadioAudioService.makeSafeHamFreq(frequency);
+            String formattedFrequency = radioAudioService.makeSafeHamFreq(frequency);
             if (formattedFrequency == null) {
                 editFrequencyTextInputEditText.setError("Enter a frequency like 144.0000");
                 editFrequencyTextInputEditText.requestFocus();

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/AddEditMemoryActivity.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/AddEditMemoryActivity.java
@@ -299,6 +299,11 @@ public class AddEditMemoryActivity extends AppCompatActivity {
             editFrequencyTextInputEditText.requestFocus();
             return;
         } else {
+            if (radioAudioService == null) {
+                editFrequencyTextInputEditText.setError("Service not available. Please try again later.");
+                editFrequencyTextInputEditText.requestFocus();
+                return;
+            }
             String formattedFrequency = radioAudioService.makeSafeHamFreq(frequency);
             if (formattedFrequency == null) {
                 editFrequencyTextInputEditText.setError("Enter a frequency like 144.0000");

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/FindRepeatersActivity.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/FindRepeatersActivity.java
@@ -576,7 +576,12 @@ public class FindRepeatersActivity extends AppCompatActivity {
             ChannelMemory memory = new ChannelMemory();
             memory.name = r.call + " • " + r.location;
             memory.group = group;
-            memory.frequency = radioAudioService.makeSafeHamFreq(String.valueOf(r.freq));
+            if (radioAudioService != null) {
+                memory.frequency = radioAudioService.makeSafeHamFreq(String.valueOf(r.freq));
+            } else {
+                Log.e("FindRepeatersActivity", "radioAudioService is null. Cannot set frequency.");
+                continue; // Skip this repeater if radioAudioService is unavailable
+            }
             if (r.offset < 0) {
                 memory.offset = ChannelMemory.OFFSET_DOWN;
             } else if (r.offset > 0) {

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/FindRepeatersActivity.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/FindRepeatersActivity.java
@@ -458,7 +458,7 @@ public class FindRepeatersActivity extends AppCompatActivity {
             r.degrees  = tryParseDouble(cols[11]);
 
             // If this repeater is below or above the frequencies this radio is capable of, skip it.
-            if (r.freq < radioAudioService.getMinRadioFreq() || r.freq > radioAudioService.getMaxRadioFreq()) {
+            if (radioAudioService == null || r.freq < radioAudioService.getMinRadioFreq() || r.freq > radioAudioService.getMaxRadioFreq()) {
                 continue;
             }
 

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/FindRepeatersActivity.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/FindRepeatersActivity.java
@@ -307,9 +307,7 @@ public class FindRepeatersActivity extends AppCompatActivity {
     @Override
     protected void onStart() {
         super.onStart();
-        serviceConnector.bind(rs -> {
-            this.radioAudioService = rs;
-        });
+        serviceConnector.bind(rs -> this.radioAudioService = rs);
     }
 
     @Override

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/FirmwareActivity.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/FirmwareActivity.java
@@ -57,7 +57,11 @@ public class FirmwareActivity extends AppCompatActivity {
 
     private CircularProgressIndicator progressIndicator;
     private TextView firmwareStatusText;
-    private View instructionText1, instructionImage, instructionText2, firmwareButtons, topLevelView;
+    private View instructionText1;
+    private View instructionImage;
+    private View instructionText2;
+    private View firmwareButtons;
+    private View topLevelView;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/FirmwareActivity.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/FirmwareActivity.java
@@ -42,6 +42,8 @@ import com.vagell.kv4pht.radio.RadioServiceConnector;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import static com.google.android.material.snackbar.BaseTransientBottomBar.LENGTH_INDEFINITE;
+
 
 public class FirmwareActivity extends AppCompatActivity {
 
@@ -158,7 +160,7 @@ public class FirmwareActivity extends AppCompatActivity {
     }
 
     private void showErrorSnackBar(UsbSerialPort port) {
-        errorSnackbar = Snackbar.make(topLevelView, FAILED_TO_MESSAGE, Snackbar.LENGTH_INDEFINITE)
+        errorSnackbar = Snackbar.make(topLevelView, FAILED_TO_MESSAGE, LENGTH_INDEFINITE)
             .setBackgroundTint(Color.rgb(140, 20, 0))
             .setTextColor(Color.WHITE)
             .setActionTextColor(Color.WHITE)

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/FirmwareActivity.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/FirmwareActivity.java
@@ -18,8 +18,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 package com.vagell.kv4pht.ui;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
-import android.content.Context;
 import android.graphics.Color;
 import android.os.Bundle;
 
@@ -37,137 +37,140 @@ import com.hoho.android.usbserial.driver.UsbSerialPort;
 
 import com.vagell.kv4pht.R;
 import com.vagell.kv4pht.firmware.FirmwareUtils;
-import com.vagell.kv4pht.radio.RadioAudioService;
+import com.vagell.kv4pht.radio.RadioServiceConnector;
 
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 
 public class FirmwareActivity extends AppCompatActivity {
-    private final ThreadPoolExecutor threadPoolExecutor = new ThreadPoolExecutor(2, 2, 0, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>());
-    private Snackbar errorSnackbar = null;
+
+    public static final CharSequence FAILED_TO_MESSAGE = "Failed to flash firmware. If it keeps failing, use kv4p.com web flasher.";
+    public static final String CONNECTING_TO_BOOTLOADER = "Connecting to bootloader...";
+    public static final String RETRY = "Retry";
+
+    private final ExecutorService executor = Executors.newFixedThreadPool(2);
+    private Snackbar errorSnackbar;
+    private RadioServiceConnector serviceConnector;
+
+    private CircularProgressIndicator progressIndicator;
+    private TextView firmwareStatusText;
+    private View instructionText1, instructionImage, instructionText2, firmwareButtons, topLevelView;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_firmware);
-        getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON); // Or firmware writing will fail when app is paused
-
-    }
-
-    @Override
-    protected void onDestroy() {
-        super.onDestroy();
-        threadPoolExecutor.shutdownNow();
+        getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+        serviceConnector = new RadioServiceConnector(this);
+        firmwareStatusText = findViewById(R.id.firmwareStatusText);
+        progressIndicator = findViewById(R.id.firmwareProgressIndicator);
+        instructionText1 = findViewById(R.id.firmwareInstructionText1);
+        instructionImage = findViewById(R.id.firmwareInstructionImage);
+        instructionText2 = findViewById(R.id.firmwareInstructionText2);
+        firmwareButtons = findViewById(R.id.firmwareButtons);
+        topLevelView = findViewById(R.id.firmwareTopLevelView);
     }
 
     @Override
     protected void onStart() {
         super.onStart();
-        startFlashing();
+        serviceConnector.bind(service -> startFlashing(service.getSerialPort()));
     }
 
     @Override
     protected void onStop() {
         super.onStop();
-        if (errorSnackbar != null) {
-            errorSnackbar.dismiss();
-        }
+        serviceConnector.unbind();
+        if (errorSnackbar != null) errorSnackbar.dismiss();
     }
 
-    private void startFlashing() {
-        setStatusText("Connecting to bootloader...");
-        findViewById(R.id.firmwareInstructionText1).setVisibility(View.VISIBLE);
-        findViewById(R.id.firmwareInstructionImage).setVisibility(View.VISIBLE);
-        findViewById(R.id.firmwareButtons).setVisibility(View.VISIBLE);
-        findViewById(R.id.firmwareInstructionText2).setVisibility(View.GONE);
-        CircularProgressIndicator progressIndicator = findViewById(R.id.firmwareProgressIndicator);
-        progressIndicator.setIndeterminate(true);
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        executor.shutdownNow();
+    }
 
-        // Start flashing, if we're not already.
-        if (FirmwareUtils.isFlashing()) {
+    @SuppressLint("UnsafeIntentLaunch")
+    public void firmwareCancelButtonClicked(View view) {
+        // TODO: actually cancel flashing
+        setResult(Activity.RESULT_CANCELED, getIntent());
+        finish();
+    }
+
+    private void setStatusText(String text) {
+        firmwareStatusText.setText(text);
+    }
+
+    private void startFlashing(UsbSerialPort serialPort) {
+        if (FirmwareUtils.isFlashing() || serialPort == null) {
+            Log.w("FirmwareActivity", "Flashing already in progress or serialPort is null.");
             return;
         }
-        final Context ctx = this;
-        threadPoolExecutor.execute(() -> {
-            UsbSerialPort serialPort = RadioAudioService.getUsbSerialPort();
-            if (null == serialPort) {
-                Log.d("DEBUG", "Error: Unexpected null serial port in FirmwareActivity.");
-                // TODO report in UI that serial port not found, with option to retry
-            }
-            FirmwareUtils.flashFirmware(ctx, serialPort, new FirmwareUtils.FirmwareCallback() {
+        updateInitialUi();
+        executor.execute(() -> FirmwareUtils.flashFirmware(
+            this,
+            serialPort,
+            new FirmwareUtils.FirmwareCallback() {
                 @Override
                 public void connectedToBootloader() {
-                    runOnUiThread(new Runnable() {
-                        @Override
-                        public void run() {
-                            setStatusText("Flashing 0%");
-                            findViewById(R.id.firmwareInstructionText1).setVisibility(View.GONE);
-                            findViewById(R.id.firmwareInstructionImage).setVisibility(View.GONE);
-                            findViewById(R.id.firmwareButtons).setVisibility(View.GONE);
-                            findViewById(R.id.firmwareInstructionText2).setVisibility(View.VISIBLE);
-                            CircularProgressIndicator progressIndicator1 = findViewById(R.id.firmwareProgressIndicator);
-                            progressIndicator1.setIndeterminate(false);
-                            progressIndicator1.setProgress(0);
-                        }
+                    runOnUiThread(() -> {
+                        setStatusText("Flashing 0%");
+                        toggleInstructionViews(false);
+                        firmwareButtons.setVisibility(View.GONE);
+                        instructionText2.setVisibility(View.VISIBLE);
+                        progressIndicator.setIndeterminate(false);
+                        progressIndicator.setProgress(0);
                     });
                 }
-
                 @Override
                 public void reportProgress(int percent) {
-                    runOnUiThread(new Runnable() {
-                        @Override
-                        public void run() {
-                            setStatusText("Flashing " + percent + "%");
-                            CircularProgressIndicator progressIndicator1 = findViewById(R.id.firmwareProgressIndicator);
-                            progressIndicator1.setIndeterminate(false);
-                            progressIndicator1.setProgress(percent);
-                        }
+                    runOnUiThread(() -> {
+                        setStatusText("Flashing " + percent + "%");
+                        progressIndicator.setProgress(percent);
                     });
                 }
-
+                @SuppressLint("UnsafeIntentLaunch")
                 @Override
                 public void doneFlashing(boolean success) {
-                    Log.d("DEBUG", "doneFlashing, success: " + success);
-
+                    Log.d("FirmwareActivity", "Flashing done: " + success);
                     if (success) {
                         setResult(Activity.RESULT_OK, getIntent());
                         finish();
                     } else {
-                        Log.d("DEBUG", "Error: Flashing firmware failed.");
-
-                        CharSequence snackbarMsg = "Failed to flash firmware. If it keeps failing, use kv4p.com web flasher.";
-                        errorSnackbar = Snackbar.make(ctx, findViewById(R.id.firmwareTopLevelView), snackbarMsg, Snackbar.LENGTH_INDEFINITE)
-                                .setBackgroundTint(Color.rgb(140, 20, 0)).setActionTextColor(Color.WHITE).setTextColor(Color.WHITE);
-                        errorSnackbar.setAction("Retry", new View.OnClickListener() {
-                                    @Override
-                                    public void onClick(View view) {
-                                        errorSnackbar.dismiss();
-                                        startFlashing();
-                                    }
-                                });
-
-                        // Make the text of the snackbar larger.
-                        TextView snackbarActionTextView = (TextView) errorSnackbar.getView().findViewById(com.google.android.material.R.id.snackbar_action);
-                        snackbarActionTextView.setTextSize(20);
-                        TextView snackbarTextView = (TextView) errorSnackbar.getView().findViewById(com.google.android.material.R.id.snackbar_text);
-                        snackbarTextView.setTextSize(20);
-
-                        errorSnackbar.show();
+                        showErrorSnackBar(serialPort);
                     }
                 }
+            }));
+    }
+
+    private void updateInitialUi() {
+        setStatusText(CONNECTING_TO_BOOTLOADER);
+        toggleInstructionViews(true);
+        firmwareButtons.setVisibility(View.VISIBLE);
+        instructionText2.setVisibility(View.GONE);
+        progressIndicator.setIndeterminate(true);
+    }
+
+    private void toggleInstructionViews(boolean showInitial) {
+        instructionText1.setVisibility(showInitial ? View.VISIBLE : View.GONE);
+        instructionImage.setVisibility(showInitial ? View.VISIBLE : View.GONE);
+    }
+
+    private void showErrorSnackBar(UsbSerialPort port) {
+        errorSnackbar = Snackbar.make(topLevelView, FAILED_TO_MESSAGE, Snackbar.LENGTH_INDEFINITE)
+            .setBackgroundTint(Color.rgb(140, 20, 0))
+            .setTextColor(Color.WHITE)
+            .setActionTextColor(Color.WHITE)
+            .setAction(RETRY, v -> {
+                errorSnackbar.dismiss();
+                startFlashing(port);
             });
-        });
-    }
-
-    private void setStatusText(String text) {
-        TextView firmwareStatusText = findViewById(R.id.firmwareStatusText);
-        firmwareStatusText.setText(text);
-    }
-
-    public void firmwareCancelButtonClicked(View view) {
-        // TODO actually cancel any firmware flashing in progress
-        setResult(Activity.RESULT_CANCELED, getIntent());
-        finish();
+        View snackbarView = errorSnackbar.getView();
+        TextView text = snackbarView.findViewById(com.google.android.material.R.id.snackbar_text);
+        TextView action = snackbarView.findViewById(com.google.android.material.R.id.snackbar_action);
+        text.setTextSize(20);
+        action.setTextSize(20);
+        errorSnackbar.show();
     }
 }

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
@@ -99,6 +99,7 @@ import java.util.stream.Collectors;
 
 import static android.view.View.GONE;
 import static android.view.View.VISIBLE;
+import static com.google.android.material.snackbar.Snackbar.LENGTH_LONG;
 
 public class MainActivity extends AppCompatActivity {
     // For transmitting audio to ESP32 / radio
@@ -429,7 +430,7 @@ public class MainActivity extends AppCompatActivity {
 
                 @Override
                 public void chatError(String text) {
-                    Snackbar snackbar = Snackbar.make(context, findViewById(R.id.mainTopLevelLayout), text, Snackbar.LENGTH_LONG)
+                    Snackbar snackbar = Snackbar.make(context, findViewById(R.id.mainTopLevelLayout), text, LENGTH_LONG)
                             .setBackgroundTint(Color.rgb(140, 20, 0))
                             .setTextColor(Color.WHITE)
                             .setAnchorView(findViewById(R.id.textChatInput));

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
@@ -100,6 +100,7 @@ import java.util.stream.Collectors;
 import static android.view.View.GONE;
 import static android.view.View.VISIBLE;
 import static com.google.android.material.snackbar.Snackbar.LENGTH_LONG;
+import static com.vagell.kv4pht.radio.RadioAudioService.INTENT_OPEN_CHAT;
 
 public class MainActivity extends AppCompatActivity {
     // For transmitting audio to ESP32 / radio
@@ -159,9 +160,6 @@ public class MainActivity extends AppCompatActivity {
     private static int MAX_AUDIO_VIZ_SIZE = 500;
     private static int MIN_TX_AUDIO_VIZ_SIZE = 200;
     private static int RECORD_ANIM_FPS = 30;
-
-    // Intents this Activity can handle besides the one that starts it in default mode.
-    public static String INTENT_OPEN_CHAT = "com.vagell.kv4pht.OPEN_CHAT_ACTION";
 
     // The main service that handles USB with the ESP32, incoming and outgoing audio, data, etc.
     private RadioAudioService radioAudioService = null;

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
@@ -1931,13 +1931,13 @@ public class MainActivity extends AppCompatActivity {
      * @param message               The message content of the notification.
      * @param tapIntentName         The intent action name to handle taps on the notification.
      */
-    private void doShowNotification(String notificationChannelId, int notificationTypeId, String title, String message, String tapIntentName) {
+    public void doShowNotification(String notificationChannelId, int notificationTypeId, String title, String message, String tapIntentName) {
         if (notificationChannelId == null || title == null || message == null) {
             Log.d("DEBUG", "Unexpected null in showNotification.");
             return;
         }
         // Has the user disallowed notifications?
-        if (ActivityCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
+        if (checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
             return;
         }
         // If they tap the notification when doing something else, come back to this app

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
@@ -217,7 +217,7 @@ public class MainActivity extends AppCompatActivity {
                 Intent intent = new Intent("com.vagell.kv4pht.EDIT_MEMORY_ACTION");
                 intent.putExtra("requestCode", REQUEST_EDIT_MEMORY);
                 intent.putExtra("memoryId", memory.memoryId);
-                intent.putExtra("isVhfRadio", (radioAudioService != null && radioAudioService.getRadioType().equals(RadioAudioService.RadioModuleType.VHF)));
+                intent.putExtra("isVhfRadio", (radioAudioService != null && radioAudioService.getRadioType() == RadioAudioService.RadioModuleType.VHF));
                 startActivityForResult(intent, REQUEST_EDIT_MEMORY);
             }
         });

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
@@ -766,7 +766,7 @@ public class MainActivity extends AppCompatActivity {
 
         String accuracyStr = (accuracy == RadioAudioService.APRS_POSITION_EXACT) ? getString(R.string.exact) : getString(R.string.approx);
         CharSequence snackbarMsg = getString(R.string.position_beacon_message_1) + accuracyStr + getString(R.string.position_beacon_message_2);
-        Snackbar beaconingSnackbar = Snackbar.make(this, findViewById(R.id.mainTopLevelLayout), snackbarMsg, Snackbar.LENGTH_LONG)
+        Snackbar beaconingSnackbar = Snackbar.make(this, findViewById(R.id.mainTopLevelLayout), snackbarMsg, LENGTH_LONG)
                 .setAction("Settings", new View.OnClickListener() {
                     @Override
                     public void onClick(View view) {
@@ -1839,7 +1839,7 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void showSimpleSnackbar(String msg) {
-        Snackbar simpleSnackbar = Snackbar.make(this, findViewById(R.id.mainTopLevelLayout), msg, Snackbar.LENGTH_LONG)
+        Snackbar simpleSnackbar = Snackbar.make(this, findViewById(R.id.mainTopLevelLayout), msg, LENGTH_LONG)
                 .setBackgroundTint(getResources().getColor(R.color.primary))
                 .setTextColor(getResources().getColor(R.color.medium_gray));
 

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
@@ -314,10 +314,10 @@ public class MainActivity extends AppCompatActivity {
                 }
 
                 @Override
-                public void setRadioType(RadioAudioService.RadioModuleType ratioType) {
-                    if (ratioType.equals(RadioAudioService.RadioModuleType.VHF)) {
+                public void setRadioType(RadioAudioService.RadioModuleType radioType) {
+                    if (radioType.equals(RadioAudioService.RadioModuleType.VHF)) {
                         showBand(BandType.BAND_VHF);
-                    } else if (ratioType.equals(RadioAudioService.RadioModuleType.UHF)) {
+                    } else if (radioType.equals(RadioAudioService.RadioModuleType.UHF)) {
                         showBand(BandType.BAND_UHF);
                     } else {
                         showBand(BandType.BAND_UNKNOWN);


### PR DESCRIPTION
This PR tidies up the radio and firmware code to fix warnings from static analysis tools like `SonarQube`. Just trying to make the code easier to work with and keep the noise down going forward.

Highlights:
* Swapped out raw int mode constants for a proper RadioMode enum(s)
* Added a RadioServiceConnector to clean up service binding in activities
* Moved handshake logic into a separate ProtocolHandshake class

No behavior changes — just cleanup and refactoring.