### PR TITLE
Switch from internal DAC to I2S PDM output

### DIFF
--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/txAudio.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/txAudio.h
@@ -25,7 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "protocol.h"
 
 bool txStreamConfigured = false;
-AnalogAudioStream out;
+I2SStream out;
 AudioInfo txInfo(AUDIO_SAMPLE_RATE, 1, 16);
 OpusAudioDecoder txDec;
 EncodedAudioStream txOut(&out, &txDec); 
@@ -37,10 +37,11 @@ const uint16_t RUNAWAY_TX_SEC = 200;
 void initI2STx() {  
   auto config = out.defaultConfig(TX_MODE);
   config.copyFrom(txInfo);
-  config.adc_pin = hw.pins.pinAudioOut;
-  config.is_blocking_write = true;
+  config.pin_data = hw.pins.pinAudioOut;
+  config.pin_ws = 27;
   config.use_apll = true;
   config.auto_clear = false;
+  config.signal_type = PDM;
   out.begin(config);
   // configure OPUS additinal parameters
   txDec.setAudioInfo(txInfo);


### PR DESCRIPTION
Switched audio output from ESP32’s built-in DAC to I2S in PDM mode. This seems to give better audio quality, even without a low-pass filter. There’s still a slight click at the end of TX on the 2.0c board, but it’s subtle and probably fine.

This also prepares us for newer ESP32 chips that don’t have a DAC, and lets us map the audio output to any pins.