### PR TITLE
Follow symlinks

### DIFF
--- a/website-src/hwconfig/.htaccess
+++ b/website-src/hwconfig/.htaccess
@@ -1,0 +1,1 @@
+Options +SymLinksIfOwnerMatch


### PR DESCRIPTION
https://help.dreamhost.com/hc/en-us/articles/216456227--htaccess-overview

> Typically, DreamHost's shared hosting environments are configured with AllowOverride All or a similar setting for user directories, allowing common .htaccess directives to function as expected. This enables users to control aspects like URL rewriting (using mod_rewrite), custom error pages, access control, and authentication within their specific website directories.

May fix: https://github.com/VanceVagell/kv4p-ht/issues/330