### PR TITLE
Disable Repeaters until radio attached

### DIFF
--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
@@ -1915,6 +1915,8 @@ public class MainActivity extends AppCompatActivity {
                 return true;
             }
         });
+        //Changes
+        moreMenu.getMenu().findItem(R.id.import_from_repeaterbook).setEnabled(radioAudioService.isRadioConnected());
         moreMenu.getMenu().findItem(R.id.flash_firmware).setEnabled(radioAudioService.isRadioConnected());
         moreMenu.show();
     }


### PR DESCRIPTION
Disabling the menu item based on the radio connection status, using the same behavior as flash_firmware, prevents the activation of the repeater search function.