### PR TITLE
Switched Android USB connection management from event-driven reconnect triggers to a periodic polling loop.

### DIFF
--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/ConnectionController.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/ConnectionController.java
@@ -21,10 +21,11 @@ final class ConnectionController {
             if (!isConnectionReady.getAsBoolean() && !attemptActive) {
                 attemptActive = true;
                 attemptConnect.run();
+                if (!running) {
+                    return;
+                }
             }
-            if (running) {
-                handler.postDelayed(this, periodMs);
-            }
+            handler.postDelayed(this, periodMs);
         }
     };
 

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/ConnectionController.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/ConnectionController.java
@@ -14,6 +14,8 @@ final class ConnectionController {
 
     private final Runnable periodicRunnable = new Runnable() {
         @Override
+        // False positive: attemptConnect.run() can call stop() and flip running to false.
+        @SuppressWarnings("java:S2589")
         public void run() {
             if (!running) {
                 return;
@@ -21,11 +23,10 @@ final class ConnectionController {
             if (!isConnectionReady.getAsBoolean() && !attemptActive) {
                 attemptActive = true;
                 attemptConnect.run();
-                if (!running) {
-                    return;
-                }
             }
-            handler.postDelayed(this, periodMs);
+            if (running) {
+                handler.postDelayed(this, periodMs);
+            }
         }
     };
 

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/ConnectionController.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/ConnectionController.java
@@ -9,16 +9,22 @@ final class ConnectionController {
     private final long periodMs;
     private final BooleanSupplier isConnectionReady;
     private final Runnable attemptConnect;
+    private boolean running = false;
     private boolean attemptActive = false;
 
     private final Runnable periodicRunnable = new Runnable() {
         @Override
         public void run() {
+            if (!running) {
+                return;
+            }
             if (!isConnectionReady.getAsBoolean() && !attemptActive) {
                 attemptActive = true;
                 attemptConnect.run();
             }
-            handler.postDelayed(this, periodMs);
+            if (running) {
+                handler.postDelayed(this, periodMs);
+            }
         }
     };
 
@@ -36,10 +42,12 @@ final class ConnectionController {
 
     void start() {
         stop();
+        running = true;
         handler.postDelayed(periodicRunnable, periodMs);
     }
 
     void stop() {
+        running = false;
         handler.removeCallbacks(periodicRunnable);
         markAttemptFinished();
     }

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/ConnectionController.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/ConnectionController.java
@@ -1,6 +1,7 @@
 package com.vagell.kv4pht.radio;
 
 import android.os.Handler;
+import android.os.Looper;
 import java.util.function.BooleanSupplier;
 
 final class ConnectionController {
@@ -40,9 +41,14 @@ final class ConnectionController {
 
     void stop() {
         handler.removeCallbacks(periodicRunnable);
+        markAttemptFinished();
     }
 
     void markAttemptFinished() {
-        attemptActive = false;
+        if (Looper.myLooper() == handler.getLooper()) {
+            attemptActive = false;
+        } else {
+            handler.post(() -> attemptActive = false);
+        }
     }
 }

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/ConnectionController.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/ConnectionController.java
@@ -1,0 +1,48 @@
+package com.vagell.kv4pht.radio;
+
+import android.os.Handler;
+import java.util.function.BooleanSupplier;
+
+final class ConnectionController {
+    private final Handler handler;
+    private final long periodMs;
+    private final BooleanSupplier isConnectionReady;
+    private final Runnable attemptConnect;
+    private boolean attemptActive = false;
+
+    private final Runnable periodicRunnable = new Runnable() {
+        @Override
+        public void run() {
+            if (!isConnectionReady.getAsBoolean() && !attemptActive) {
+                attemptActive = true;
+                attemptConnect.run();
+            }
+            handler.postDelayed(this, periodMs);
+        }
+    };
+
+    ConnectionController(
+        Handler handler,
+        long periodMs,
+        BooleanSupplier isConnectionReady,
+        Runnable attemptConnect
+    ) {
+        this.handler = handler;
+        this.periodMs = periodMs;
+        this.isConnectionReady = isConnectionReady;
+        this.attemptConnect = attemptConnect;
+    }
+
+    void start() {
+        stop();
+        handler.postDelayed(periodicRunnable, periodMs);
+    }
+
+    void stop() {
+        handler.removeCallbacks(periodicRunnable);
+    }
+
+    void markAttemptFinished() {
+        attemptActive = false;
+    }
+}

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/ProtocolHandshake.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/ProtocolHandshake.java
@@ -38,11 +38,13 @@ import java.util.concurrent.TimeoutException;
 @SuppressWarnings({"javaarchitecture:S7027"})
 class ProtocolHandshake {
     private static final String TAG = ProtocolHandshake.class.getSimpleName();
-    private static final int HELLO_TIMEOUT_MS = 1000;
+    private static final int HELLO_TIMEOUT_MS = 1500;
     private static final int FIRMWARE_VERSION_TIMEOUT_MS = 60000;
     private enum HandshakeResult {INVALID, TOO_OLD, OK, RADIO_MODULE_NOT_FOUND}
     private final RadioAudioService radioAudioService;
     private ScheduledExecutorService protocolScheduler = Executors.newSingleThreadScheduledExecutor();
+    private int handshakeSeq = 0;
+    private int activeHandshakeId = 0;
 
     /**
      * Future completed when HELLO is received or timeout occurs.
@@ -65,47 +67,52 @@ class ProtocolHandshake {
         if (protocolScheduler.isShutdown()) {
             protocolScheduler = Executors.newSingleThreadScheduledExecutor();
         }
-        Log.i(TAG, "Starting protocol handshake with ESP32.");
-        startFor(waitForHello()
-            .thenCompose(this::sendConfigStep));
+        int handshakeId = ++handshakeSeq;
+        activeHandshakeId = handshakeId;
+        Log.i(TAG, handshakeLog(handshakeId, "start(): waiting for HELLO"));
+        startFor(handshakeId, waitForHello(handshakeId)
+            .thenCompose(ignored -> sendConfigStep(handshakeId, ignored)));
     }
 
     public void onDestroy() {
         protocolScheduler.shutdownNow();
     }
 
-    private void startFor(CompletionStage<Void> chain) {
+    private void startFor(int handshakeId, CompletionStage<Void> chain) {
         chain
-            .thenCompose(this::waitForFirmwareVersion)
-            .thenCompose(this::checkFirmwareVersionAndRadioStatus)
-            .thenAccept(this::handleResult)
+            .thenCompose(ignored -> waitForFirmwareVersion(handshakeId, ignored))
+            .thenCompose(version -> checkFirmwareVersionAndRadioStatus(handshakeId, version))
+            .thenAccept(res -> handleResult(handshakeId, res))
             .exceptionally(ex -> {
-                Log.e(TAG, "Handshake chain failed: " + ex.getMessage());
+                Log.e(TAG, handshakeLog(handshakeId, "chain failed"), ex);
                 radioAudioService.setMode(RadioMode.BAD_FIRMWARE);
                 radioAudioService.getCallbacks().missingFirmware();
                 return null;
             })
-            .whenComplete((ignored, ex) -> radioAudioService.onHandshakeCompleted());
+            .whenComplete((ignored, ex) -> {
+                Log.d(TAG, handshakeLog(handshakeId, "complete() ex=" + (ex != null)));
+                radioAudioService.onHandshakeCompleted();
+            });
     }
 
-    private void handleResult(HandshakeResult res) {
+    private void handleResult(int handshakeId, HandshakeResult res) {
         switch (res) {
             case INVALID:
-                Log.e(TAG, "Cannot parse FirmwareVersion packet.");
+                Log.e(TAG, handshakeLog(handshakeId, "invalid FirmwareVersion packet"));
                 radioAudioService.getCallbacks().missingFirmware();
                 radioAudioService.setMode(RadioMode.BAD_FIRMWARE);
                 return;
             case TOO_OLD:
-                Log.w(TAG, "Firmware version too old, cannot proceed.");
+                Log.w(TAG, handshakeLog(handshakeId, "firmware version too old"));
                 radioAudioService.setMode(RadioMode.BAD_FIRMWARE);
                 return;
             case RADIO_MODULE_NOT_FOUND:
-                Log.e(TAG, "Radio module not found, cannot proceed.");
+                Log.w(TAG, handshakeLog(handshakeId, "radio module not found"));
                 radioAudioService.setMode(RadioMode.BAD_FIRMWARE);
                 radioAudioService.getCallbacks().radioModuleNotFound();
                 return;
             case OK:
-                Log.i(TAG, "Firmware version OK, proceeding with radio communication.");
+                Log.i(TAG, handshakeLog(handshakeId, "firmware version OK; proceeding with radio communication"));
                 radioAudioService.setMode(RadioMode.RX);
                 // Turn off scanning if it was on (e.g. if radio was unplugged briefly and reconnected)
                 radioAudioService.setScanning(false);
@@ -120,11 +127,13 @@ class ProtocolHandshake {
      */
     public void onHelloReceived() {
         if (!waitForHello.isDone()) {
-            Log.d(TAG, "HELLO received from ESP32.");
+            Log.d(TAG, handshakeLog(activeHandshakeId, "HELLO received"));
             waitForHello.complete(null);
         } else {
-            Log.i(TAG, "ESP32 rebooted, restarting handshake from config step.");
-            startFor(sendConfigStep(null)); // ESP32 rebooted mid-session, restart from config step
+            int handshakeId = ++handshakeSeq;
+            activeHandshakeId = handshakeId;
+            Log.i(TAG, handshakeLog(handshakeId, "HELLO received after wait completed; restarting from config step"));
+            startFor(handshakeId, sendConfigStep(handshakeId, null)); // ESP32 rebooted mid-session, restart from config step
         }
     }
 
@@ -137,7 +146,7 @@ class ProtocolHandshake {
      */
     public void onVersionReceived(Optional<Protocol.FirmwareVersion> version) {
         if (!waitFirmwareVersion.isDone()) {
-            Log.d(TAG, "Firmware version received from ESP32: " + version);
+            Log.d(TAG, handshakeLog(activeHandshakeId, "firmware version received: " + version));
             waitFirmwareVersion.complete(version);
         }
     }
@@ -147,10 +156,12 @@ class ProtocolHandshake {
      *
      * @return A future that completes when HELLO is received or times out.
      */
-    private CompletableFuture<Void> waitForHello() {
+    private CompletableFuture<Void> waitForHello(int handshakeId) {
         waitForHello = new CompletableFuture<>();
+        Log.d(TAG, handshakeLog(handshakeId, "waitForHello(): timeout=" + HELLO_TIMEOUT_MS + "ms"));
         protocolScheduler.schedule(() -> {
             if (!waitForHello.isDone()) {
+                Log.w(TAG, handshakeLog(handshakeId, "waitForHello(): timed out"));
                 waitForHello.completeExceptionally(new TimeoutException("Timeout waiting for HELLO"));
             }
         }, HELLO_TIMEOUT_MS, TimeUnit.MILLISECONDS);
@@ -163,13 +174,13 @@ class ProtocolHandshake {
      *
      * @return A future that completes once the config is sent.
      */
-    private CompletableFuture<Void> sendConfigStep(Void ignored) {
+    private CompletableFuture<Void> sendConfigStep(int handshakeId, Void ignored) {
         return CompletableFuture.runAsync(() -> {
             radioAudioService.getCallbacks().radioModuleHandshake();
             radioAudioService.setMode(RadioMode.STARTUP);
             radioAudioService.getHostToEsp32().stop();
             Protocol.Config cfg = Protocol.Config.builder().isHigh(radioAudioService.isHighPower()).build();
-            Log.d(TAG, "Sending configuration to ESP32: " + cfg);
+            Log.d(TAG, handshakeLog(handshakeId, "sendConfigStep(): sending " + cfg));
             radioAudioService.getHostToEsp32().config(cfg);
         });
     }
@@ -179,10 +190,12 @@ class ProtocolHandshake {
      *
      * @return A future that completes when version is received or times out.
      */
-    private CompletableFuture<Optional<Protocol.FirmwareVersion>> waitForFirmwareVersion(Void ignored) {
+    private CompletableFuture<Optional<Protocol.FirmwareVersion>> waitForFirmwareVersion(int handshakeId, Void ignored) {
         waitFirmwareVersion = new CompletableFuture<>();
+        Log.d(TAG, handshakeLog(handshakeId, "waitForFirmwareVersion(): timeout=" + FIRMWARE_VERSION_TIMEOUT_MS + "ms"));
         protocolScheduler.schedule(() -> {
             if (!waitFirmwareVersion.isDone()) {
+                Log.w(TAG, handshakeLog(handshakeId, "waitForFirmwareVersion(): timed out"));
                 waitFirmwareVersion.completeExceptionally(new TimeoutException("Timeout waiting for firmware version"));
             }
         }, FIRMWARE_VERSION_TIMEOUT_MS, TimeUnit.MILLISECONDS);
@@ -197,12 +210,14 @@ class ProtocolHandshake {
      * @return A future that completes when initialization is done.
      * @noinspection OptionalUsedAsFieldOrParameterType
      */
-    private CompletableFuture<HandshakeResult> checkFirmwareVersionAndRadioStatus(Optional<Protocol.FirmwareVersion> firmwareVersion) {
+    private CompletableFuture<HandshakeResult> checkFirmwareVersionAndRadioStatus(int handshakeId, Optional<Protocol.FirmwareVersion> firmwareVersion) {
         return CompletableFuture.supplyAsync(() -> {
             if (!firmwareVersion.isPresent()) {
+                Log.w(TAG, handshakeLog(handshakeId, "checkFirmwareVersionAndRadioStatus(): no firmware version present"));
                 return HandshakeResult.INVALID;
             }
             final Protocol.FirmwareVersion ver = firmwareVersion.get();
+            Log.d(TAG, handshakeLog(handshakeId, "checkFirmwareVersionAndRadioStatus(): version=" + ver));
             radioAudioService.getCallbacks().firmwareVersionReceived(ver.getVer());
             if (ver.getVer() < FirmwareUtils.PACKAGED_FIRMWARE_VER) {
                 radioAudioService.getCallbacks().outdatedFirmware(ver.getVer());
@@ -220,5 +235,12 @@ class ProtocolHandshake {
                 return HandshakeResult.OK;
             }
         });
+    }
+
+    private String handshakeLog(int handshakeId, String message) {
+        return "handshake#" + handshakeId
+            + "/connect#" + radioAudioService.getActiveUsbConnectAttemptId()
+            + " " + RadioAudioService.threadTag()
+            + " " + message;
     }
 }

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/ProtocolHandshake.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/ProtocolHandshake.java
@@ -84,7 +84,8 @@ class ProtocolHandshake {
                 radioAudioService.setMode(RadioMode.BAD_FIRMWARE);
                 radioAudioService.getCallbacks().missingFirmware();
                 return null;
-            });
+            })
+            .whenComplete((ignored, ex) -> radioAudioService.onHandshakeCompleted());
     }
 
     private void handleResult(HandshakeResult res) {

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/ProtocolHandshake.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/ProtocolHandshake.java
@@ -71,7 +71,7 @@ class ProtocolHandshake {
         activeHandshakeId = handshakeId;
         Log.i(TAG, handshakeLog(handshakeId, "start(): waiting for HELLO"));
         startFor(handshakeId, waitForHello(handshakeId)
-            .thenCompose(ignored -> sendConfigStep(handshakeId, ignored)));
+            .thenCompose(ignored -> sendConfigStep(handshakeId)));
     }
 
     public void onDestroy() {
@@ -80,7 +80,7 @@ class ProtocolHandshake {
 
     private void startFor(int handshakeId, CompletionStage<Void> chain) {
         chain
-            .thenCompose(ignored -> waitForFirmwareVersion(handshakeId, ignored))
+            .thenCompose(ignored -> waitForFirmwareVersion(handshakeId))
             .thenCompose(version -> checkFirmwareVersionAndRadioStatus(handshakeId, version))
             .thenAccept(res -> handleResult(handshakeId, res))
             .exceptionally(ex -> {
@@ -133,7 +133,7 @@ class ProtocolHandshake {
             int handshakeId = ++handshakeSeq;
             activeHandshakeId = handshakeId;
             Log.i(TAG, handshakeLog(handshakeId, "HELLO received after wait completed; restarting from config step"));
-            startFor(handshakeId, sendConfigStep(handshakeId, null)); // ESP32 rebooted mid-session, restart from config step
+            startFor(handshakeId, sendConfigStep(handshakeId)); // ESP32 rebooted mid-session, restart from config step
         }
     }
 
@@ -174,7 +174,7 @@ class ProtocolHandshake {
      *
      * @return A future that completes once the config is sent.
      */
-    private CompletableFuture<Void> sendConfigStep(int handshakeId, Void ignored) {
+    private CompletableFuture<Void> sendConfigStep(int handshakeId) {
         return CompletableFuture.runAsync(() -> {
             radioAudioService.getCallbacks().radioModuleHandshake();
             radioAudioService.setMode(RadioMode.STARTUP);
@@ -190,7 +190,7 @@ class ProtocolHandshake {
      *
      * @return A future that completes when version is received or times out.
      */
-    private CompletableFuture<Optional<Protocol.FirmwareVersion>> waitForFirmwareVersion(int handshakeId, Void ignored) {
+    private CompletableFuture<Optional<Protocol.FirmwareVersion>> waitForFirmwareVersion(int handshakeId) {
         waitFirmwareVersion = new CompletableFuture<>();
         Log.d(TAG, handshakeLog(handshakeId, "waitForFirmwareVersion(): timeout=" + FIRMWARE_VERSION_TIMEOUT_MS + "ms"));
         protocolScheduler.schedule(() -> {

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
@@ -549,7 +549,9 @@ public class RadioAudioService extends Service implements PacketHandler {
         super.onDestroy();
         if (isConnectionReady() && (mode == RadioMode.RX || mode == RadioMode.TX || mode == RadioMode.SCAN)) {
             try {
+                Log.d(TAG, "Sending stop to ESP32...");
                 hostToEsp32.stop();
+                Thread.sleep(100);
             } catch (Exception ignored) {
                 // Ignore, we are shutting down anyway.
             }

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
@@ -552,6 +552,8 @@ public class RadioAudioService extends Service implements PacketHandler {
                 Log.d(TAG, "Sending stop to ESP32...");
                 hostToEsp32.stop();
                 Thread.sleep(100);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
             } catch (Exception ignored) {
                 // Ignore, we are shutting down anyway.
             }

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
@@ -243,6 +243,10 @@ public class RadioAudioService extends Service implements PacketHandler {
     private @NonNull RadioAudioServiceCallbacks callbacks = NO_OP_CALLBACKS;
     private final ProtocolHandshake protocolHandshake = new ProtocolHandshake(this);
     private final Handler handler = new Handler(Looper.getMainLooper());
+    private static final long CONNECT_RETRY_PERIOD_MS = 500L;
+    private final ConnectionController connectionController =
+        new ConnectionController(handler, CONNECT_RETRY_PERIOD_MS, this::isConnectionReady, this::attemptUsbConnect);
+    private boolean radioMissingNotified = false;
     private Runnable txTimeoutHandler;
     private LiveData<List<ChannelMemory>> channelMemoriesLiveData = null;
 
@@ -453,7 +457,7 @@ public class RadioAudioService extends Service implements PacketHandler {
         usbManager = (UsbManager) getSystemService(Context.USB_SERVICE);
         createNotificationChannels();
         initAudioTrack();
-        handler.postDelayed(this::findESP32Device, 10);
+        connectionController.start();
     }
 
     @Override
@@ -539,6 +543,7 @@ public class RadioAudioService extends Service implements PacketHandler {
     @Override
     public void onDestroy() {
         super.onDestroy();
+        connectionController.stop();
 
         protocolHandshake.onDestroy();
 
@@ -795,11 +800,43 @@ public class RadioAudioService extends Service implements PacketHandler {
     }
 
     public void reconnectViaUSB() {
-        findESP32Device();
+        Log.i(TAG, "reconnectViaUSB()");
+        // Re-plug is an explicit user/device action; allow connection attempts again.
+        radioMissingNotified = false;
+        connectionController.markAttemptFinished();
     }
 
-    private void findESP32Device() {
-        Log.i(TAG, "findESP32Device()");
+    private boolean isConnectionReady() {
+        return hostToEsp32 != null
+            && serialPort != null
+            && usbIoManager != null;
+    }
+
+    private void closePortAndReset() {
+        hostToEsp32 = null;
+        if (usbIoManager != null) {
+            try {
+                usbIoManager.stop();
+            } catch (Exception ignored) {
+            }
+            usbIoManager = null;
+        }
+        if (serialPort != null) {
+            try {
+                serialPort.close();
+            } catch (Exception ignored) {
+            }
+            serialPort = null;
+        }
+    }
+
+    private void attemptUsbConnect() {
+        Log.i(TAG, "attemptUsbConnect()");
+        if (isConnectionReady()) {
+            Log.i(TAG, "Already connected to ESP32, skipping search.");
+            connectionController.markAttemptFinished();
+            return;
+        }
         setMode(RadioMode.STARTUP);
         setRadioType(RadioModuleType.UNKNOWN);
         Optional<UsbDevice> device = usbManager.getDeviceList().values().stream()
@@ -857,6 +894,7 @@ public class RadioAudioService extends Service implements PacketHandler {
             serialPort.setParameters(115200, 8, UsbSerialPort.STOPBITS_1, UsbSerialPort.PARITY_NONE);
         } catch (Exception e) {
             Log.e(TAG, "Error: couldn't open USB serial port.");
+            closePortAndReset();
             radioMissing();
             return;
         }
@@ -877,14 +915,8 @@ public class RadioAudioService extends Service implements PacketHandler {
                 if (audioTrack != null) {
                     audioTrack.stop();
                 }
-                connection.close();
-                try {
-                    serialPort.close();
-                } catch (Exception ignored) {
-                    // Ignore, we don't care if it fails to close.
-                }
-                // Attempt to reconnect after the brief pause above.
-                handler.postDelayed(() -> findESP32Device(), 1000);
+                closePortAndReset();
+                radioMissing();
             }
         });
         usbIoManager.setWriteBufferSize(90000); // Must be large enough that ESP32 can take its time accepting our bytes without overrun.
@@ -898,6 +930,8 @@ public class RadioAudioService extends Service implements PacketHandler {
 
     // Callback for ProtocolHandshake
     public void radioConnected() {
+        connectionController.markAttemptFinished();
+        radioMissingNotified = false;
         // Acquire WakeLock if not already held to ensure audio processing continues in background.
         if (wakeLock != null && !wakeLock.isHeld()) {
             wakeLock.acquire();
@@ -907,11 +941,19 @@ public class RadioAudioService extends Service implements PacketHandler {
 
     // Called in many situations where radio connection is found to be broken
     private void radioMissing() {
-        hostToEsp32 = null;
-        callbacks.radioMissing(); // Notify UI that radio wasn't found
+        connectionController.markAttemptFinished();
+        closePortAndReset();
+        if (!radioMissingNotified) {
+            radioMissingNotified = true;
+            callbacks.radioMissing(); // Notify UI only on transition into missing state
+        }
         if (wakeLock != null && wakeLock.isHeld()) {
             wakeLock.release(); // Don't keep screen on
         }
+    }
+
+    void onHandshakeCompleted() {
+        connectionController.markAttemptFinished();
     }
 
     /**

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
@@ -547,8 +547,14 @@ public class RadioAudioService extends Service implements PacketHandler {
     @Override
     public void onDestroy() {
         super.onDestroy();
+        if (isConnectionReady() && (mode == RadioMode.RX || mode == RadioMode.TX || mode == RadioMode.SCAN)) {
+            try {
+                hostToEsp32.stop();
+            } catch (Exception ignored) {
+                // Ignore, we are shutting down anyway.
+            }
+        }
         connectionController.stop();
-
         protocolHandshake.onDestroy();
 
         // Clean up APRS beacon executor

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
@@ -194,6 +194,8 @@ public class RadioAudioService extends Service implements PacketHandler {
     @Getter
     private Protocol.Sender hostToEsp32;
     private final FrameParser esp32DataStreamParser = new FrameParser(this::handleParsedCommand);
+    private int usbConnectAttemptSeq = 0;
+    private int activeUsbConnectAttemptId = 0;
 
     // === AFSK Modem ===
     private final PacketModulator afskModulator = new Afsk1200Modulator(AUDIO_SAMPLE_RATE);
@@ -802,7 +804,7 @@ public class RadioAudioService extends Service implements PacketHandler {
     }
 
     public void reconnectViaUSB() {
-        Log.i(TAG, "reconnectViaUSB()");
+        Log.i(TAG, connectLog("reconnectViaUSB(): clearing pending state for next attempt"));
         usbPermissionRequestPending = false;
         // Re-plug is an explicit user/device action; allow connection attempts again.
         radioMissingNotified = false;
@@ -810,7 +812,7 @@ public class RadioAudioService extends Service implements PacketHandler {
     }
 
     public void onUsbPermissionDenied() {
-        Log.w(TAG, "USB permission denied.");
+        Log.w(TAG, connectLog("USB permission denied by system dialog"));
         usbPermissionRequestPending = false;
         radioMissing();
     }
@@ -842,9 +844,10 @@ public class RadioAudioService extends Service implements PacketHandler {
     }
 
     private void attemptUsbConnect() {
-        Log.i(TAG, "attemptUsbConnect()");
+        activeUsbConnectAttemptId = ++usbConnectAttemptSeq;
+        Log.d(TAG, connectLog("attemptUsbConnect(): starting; state=" + connectionStateSummary()));
         if (isConnectionReady()) {
-            Log.i(TAG, "Already connected to ESP32, skipping search.");
+            Log.d(TAG, connectLog("attemptUsbConnect(): already connected, skipping enumeration"));
             connectionController.markAttemptFinished();
             return;
         }
@@ -854,19 +857,19 @@ public class RadioAudioService extends Service implements PacketHandler {
             .filter(this::isESP32Device)
             .findFirst();
         if (device.isPresent()) {
-            Log.i(TAG, "Found ESP32.");
+            Log.d(TAG, connectLog("attemptUsbConnect(): found ESP32 device"));
             callbacks.hideSnackBar();
             setupSerialConnection();
             return;
         }
-        Log.w(TAG, "No ESP32 detected");
+        Log.d(TAG, connectLog("attemptUsbConnect(): no ESP32 detected"));
         radioMissing();
     }
 
     private boolean isESP32Device(UsbDevice device) {
         int vendorId = device.getVendorId();
         int productId = device.getProductId();
-        Log.i(TAG, String.format("Checking USB device: vendorId=%d, productId=%d, product=\"%s\"",
+        Log.d(TAG, String.format("Checking USB device: vendorId=%d, productId=%d, product=\"%s\"",
             vendorId, productId, device.getProductName()));
         for (int i = 0; i < ESP32_VENDOR_IDS.length; i++) {
             if (vendorId == ESP32_VENDOR_IDS[i] && productId == ESP32_PRODUCT_IDS[i]) {
@@ -881,12 +884,12 @@ public class RadioAudioService extends Service implements PacketHandler {
      * If no ESP32 is found, it will call radioMissing() on the callbacks.
      */
     public void setupSerialConnection() {
-        Log.i(TAG, "Setting up serial connection to ESP32...");
+        Log.d(TAG, connectLog("setupSerialConnection(): begin"));
         // Find all available drivers from attached devices.
         UsbManager manager = (UsbManager) getSystemService(Context.USB_SERVICE);
         List<UsbSerialDriver> availableDrivers = UsbSerialProber.getDefaultProber().findAllDrivers(manager);
         if (availableDrivers.isEmpty()) {
-            Log.e(TAG, "Error: no available USB drivers.");
+            Log.d(TAG, connectLog("setupSerialConnection(): no available USB drivers"));
             radioMissing();
             return;
         }
@@ -894,10 +897,10 @@ public class RadioAudioService extends Service implements PacketHandler {
         UsbSerialDriver driver = availableDrivers.get(0);
         if (!manager.hasPermission(driver.getDevice())) {
             if (usbPermissionRequestPending) {
-                Log.i(TAG, "USB permission request already pending.");
+                Log.d(TAG, connectLog("setupSerialConnection(): USB permission request already pending"));
                 return;
             }
-            Log.w(TAG, "No USB permission yet; requesting permission.");
+            Log.i(TAG, connectLog("setupSerialConnection(): requesting USB permission"));
             usbPermissionRequestPending = true;
             PendingIntent permissionIntent = PendingIntent.getBroadcast(
                 this,
@@ -911,17 +914,17 @@ public class RadioAudioService extends Service implements PacketHandler {
         usbPermissionRequestPending = false;
         UsbDeviceConnection connection = manager.openDevice(driver.getDevice());
         if (connection == null) {
-            Log.e(TAG, "Error: couldn't open USB device.");
+            Log.w(TAG, connectLog("setupSerialConnection(): couldn't open USB device"));
             radioMissing();
             return;
         }
         serialPort = driver.getPorts().get(0); // Most devices have just one port (port 0)
-        Log.i(TAG, "serialPort: " + serialPort);
+        Log.d(TAG, connectLog("setupSerialConnection(): serialPort=" + serialPort));
         try {
             serialPort.open(connection);
             serialPort.setParameters(115200, 8, UsbSerialPort.STOPBITS_1, UsbSerialPort.PARITY_NONE);
         } catch (Exception e) {
-            Log.e(TAG, "Error: couldn't open USB serial port.");
+            Log.w(TAG, connectLog("setupSerialConnection(): couldn't open USB serial port"), e);
             closePortAndReset();
             radioMissing();
             return;
@@ -939,7 +942,7 @@ public class RadioAudioService extends Service implements PacketHandler {
             }
             @Override
             public void onRunError(Exception e) {
-                Log.e(TAG, "Error reading from ESP32.");
+                Log.w(TAG, connectLog("onRunError(): error reading from ESP32; state=" + connectionStateSummary()), e);
                 if (audioTrack != null) {
                     audioTrack.stop();
                 }
@@ -952,12 +955,13 @@ public class RadioAudioService extends Service implements PacketHandler {
         usbIoManager.setReadBufferCount(16 * 2);
         usbIoManager.start();
         hostToEsp32 = new Protocol.Sender(usbIoManager);
-        Log.i(TAG, "Connected to ESP32.");
+        Log.i(TAG, connectLog("setupSerialConnection(): serial transport connected; starting handshake"));
         protocolHandshake.start();
     }
 
     // Callback for ProtocolHandshake
     public void radioConnected() {
+        Log.i(TAG, connectLog("radioConnected(): handshake complete; state=" + connectionStateSummary()));
         connectionController.markAttemptFinished();
         radioMissingNotified = false;
         // Acquire WakeLock if not already held to ensure audio processing continues in background.
@@ -969,6 +973,7 @@ public class RadioAudioService extends Service implements PacketHandler {
 
     // Called in many situations where radio connection is found to be broken
     private void radioMissing() {
+        Log.i(TAG, connectLog("radioMissing(): state=" + connectionStateSummary()));
         connectionController.markAttemptFinished();
         closePortAndReset();
         if (!radioMissingNotified) {
@@ -981,7 +986,30 @@ public class RadioAudioService extends Service implements PacketHandler {
     }
 
     void onHandshakeCompleted() {
+        Log.d(TAG, connectLog("onHandshakeCompleted(): state=" + connectionStateSummary()));
         connectionController.markAttemptFinished();
+    }
+
+    int getActiveUsbConnectAttemptId() {
+        return activeUsbConnectAttemptId;
+    }
+
+    private String connectLog(String message) {
+        return "connect#" + activeUsbConnectAttemptId + " " + threadTag() + " " + message;
+    }
+
+    private String connectionStateSummary() {
+        return "mode=" + mode
+            + ",hostToEsp32=" + (hostToEsp32 != null)
+            + ",serialPort=" + (serialPort != null)
+            + ",usbIoManager=" + (usbIoManager != null)
+            + ",usbPermissionPending=" + usbPermissionRequestPending
+            + ",radioMissingNotified=" + radioMissingNotified;
+    }
+
+    static String threadTag() {
+        Thread thread = Thread.currentThread();
+        return "thread=" + thread.getName() + "#" + thread.getId();
     }
 
     /**

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
@@ -1157,7 +1157,7 @@ public class RadioAudioService extends Service implements PacketHandler {
     }
 
     public boolean isRadioConnected() {
-        return hostToEsp32 != null;
+        return isConnectionReady() && mode != RadioMode.STARTUP;
     }
 
     /**

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
@@ -818,6 +818,7 @@ public class RadioAudioService extends Service implements PacketHandler {
             try {
                 usbIoManager.stop();
             } catch (Exception ignored) {
+                // Best-effort cleanup during teardown; transport may already be stopping.
             }
             usbIoManager = null;
         }
@@ -825,6 +826,7 @@ public class RadioAudioService extends Service implements PacketHandler {
             try {
                 serialPort.close();
             } catch (Exception ignored) {
+                // Best-effort cleanup during teardown; port may already be closed.
             }
             serialPort = null;
         }

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
@@ -547,17 +547,7 @@ public class RadioAudioService extends Service implements PacketHandler {
     @Override
     public void onDestroy() {
         super.onDestroy();
-        if (isConnectionReady() && (mode == RadioMode.RX || mode == RadioMode.TX || mode == RadioMode.SCAN)) {
-            try {
-                Log.d(TAG, "Sending stop to ESP32...");
-                hostToEsp32.stop();
-                Thread.sleep(100);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            } catch (Exception ignored) {
-                // Ignore, we are shutting down anyway.
-            }
-        }
+        tryToStopRadioModule();
         connectionController.stop();
         protocolHandshake.onDestroy();
 
@@ -591,6 +581,20 @@ public class RadioAudioService extends Service implements PacketHandler {
         }
         wakeLock = null;
         stopForeground(true);
+    }
+
+    private void tryToStopRadioModule() {
+        if (isConnectionReady() && (mode == RadioMode.RX || mode == RadioMode.TX || mode == RadioMode.SCAN)) {
+            try {
+                Log.d(TAG, "Sending stop to ESP32...");
+                hostToEsp32.stop();
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } catch (Exception ignored) {
+                // Ignore, we are shutting down anyway.
+            }
+        }
     }
 
     @Override

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
@@ -819,6 +819,12 @@ public class RadioAudioService extends Service implements PacketHandler {
         connectionController.markAttemptFinished();
     }
 
+    public void renegotiateAfterFlashing() {
+        Log.i(TAG, connectLog("renegotiateAfterFlashing(): closing port and resetting state before renegotiation"));
+        closePortAndReset();
+        reconnectViaUSB();
+    }
+
     public void onUsbPermissionDenied() {
         Log.w(TAG, connectLog("USB permission denied by system dialog"));
         usbPermissionRequestPending = false;

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
@@ -110,6 +110,7 @@ public class RadioAudioService extends Service implements PacketHandler {
     // === Constants ===
     private static final String TAG = RadioAudioService.class.getSimpleName();
     private static final String FIRMWARE_TAG = "firmware";
+    private static final String ACTION_USB_PERMISSION = "com.vagell.kv4pht.USB_PERMISSION";
     private static final int RUNAWAY_TX_TIMEOUT_SEC = 180;
     // Intents this Activity can handle besides the one that starts it in default mode.
     public static final String INTENT_OPEN_CHAT = "com.vagell.kv4pht.OPEN_CHAT_ACTION";
@@ -189,6 +190,7 @@ public class RadioAudioService extends Service implements PacketHandler {
     @Getter
     private UsbSerialPort serialPort;
     private SerialInputOutputManager usbIoManager;
+    private boolean usbPermissionRequestPending = false;
     @Getter
     private Protocol.Sender hostToEsp32;
     private final FrameParser esp32DataStreamParser = new FrameParser(this::handleParsedCommand);
@@ -801,9 +803,16 @@ public class RadioAudioService extends Service implements PacketHandler {
 
     public void reconnectViaUSB() {
         Log.i(TAG, "reconnectViaUSB()");
+        usbPermissionRequestPending = false;
         // Re-plug is an explicit user/device action; allow connection attempts again.
         radioMissingNotified = false;
         connectionController.markAttemptFinished();
+    }
+
+    public void onUsbPermissionDenied() {
+        Log.w(TAG, "USB permission denied.");
+        usbPermissionRequestPending = false;
+        radioMissing();
     }
 
     private boolean isConnectionReady() {
@@ -883,6 +892,23 @@ public class RadioAudioService extends Service implements PacketHandler {
         }
         // Open a connection to the first available driver.
         UsbSerialDriver driver = availableDrivers.get(0);
+        if (!manager.hasPermission(driver.getDevice())) {
+            if (usbPermissionRequestPending) {
+                Log.i(TAG, "USB permission request already pending.");
+                return;
+            }
+            Log.w(TAG, "No USB permission yet; requesting permission.");
+            usbPermissionRequestPending = true;
+            PendingIntent permissionIntent = PendingIntent.getBroadcast(
+                this,
+                0,
+                new Intent(ACTION_USB_PERMISSION),
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE
+            );
+            manager.requestPermission(driver.getDevice(), permissionIntent);
+            return;
+        }
+        usbPermissionRequestPending = false;
         UsbDeviceConnection connection = manager.openDevice(driver.getDevice());
         if (connection == null) {
             Log.e(TAG, "Error: couldn't open USB device.");

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
@@ -613,7 +613,6 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onResume() {
         super.onResume();
-        viewModel.loadDataAsync(this::applySettings);
         // If we lost reference to the radioAudioService, startAndBindRadioAudioService();
         startAndBindRadioAudioService();
     }
@@ -1827,7 +1826,9 @@ public class MainActivity extends AppCompatActivity {
                 }
                 break;
             case REQUEST_SETTINGS:
-                // Don't need to do anything here, since settings are applied in onResume() anyway.
+                if (resultCode == Activity.RESULT_OK) {
+                    viewModel.loadDataAsync(this::applySettings);
+                }
                 break;
             case REQUEST_FIRMWARE:
                 if (resultCode == Activity.RESULT_OK) {

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
@@ -301,8 +301,8 @@ public class MainActivity extends AppCompatActivity {
         filter.addAction(ACTION_USB_PERMISSION);
         filter.addAction(UsbManager.ACTION_USB_DEVICE_ATTACHED);
         filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);
-        registerReceiver(usbReceiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED);
-        registerReceiver(serviceShutdownReceiver, new IntentFilter(RadioAudioService.ACTION_SERVICE_STOPPING), ContextCompat.RECEIVER_NOT_EXPORTED);
+        ContextCompat.registerReceiver(this, usbReceiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED);
+        registerReceiver(serviceShutdownReceiver, new IntentFilter(RadioAudioService.ACTION_SERVICE_STOPPING), Context.RECEIVER_NOT_EXPORTED);
         viewModel.loadDataAsync(this::applySettings);
     }
 

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
@@ -1834,10 +1834,9 @@ public class MainActivity extends AppCompatActivity {
             case REQUEST_FIRMWARE:
                 if (resultCode == Activity.RESULT_OK) {
                     showSimpleSnackbar(getString(R.string.successfully_updated_firmware));
-
                     // Try to reconnect now that the kv4p HT firmware should be present
-                    if (null != radioAudioService) {
-                        radioAudioService.reconnectViaUSB();
+                    if (radioAudioService != null) {
+                        radioAudioService.renegotiateAfterFlashing();
                     }
                 }
                 break;

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
@@ -96,6 +96,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -597,6 +598,7 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onDestroy() {
         super.onDestroy();
+        unregisterReceiver(usbReceiver);
         unregisterReceiver(serviceShutdownReceiver);
         try {
             threadPoolExecutor.shutdownNow();
@@ -1326,9 +1328,8 @@ public class MainActivity extends AppCompatActivity {
 
                 // Save most recent memory so we can restore it on app restart
                 // Could be null if user is just listening to scan in another app, etc.
-                threadPoolExecutor.execute(new Runnable() {
-                    @Override
-                    public void run() {
+                try {
+                    threadPoolExecutor.execute(() -> {
                         AppSetting lastMemoryIdSetting = viewModel.getAppDb().appSettingDao().getByName(AppSetting.SETTING_LAST_MEMORY_ID);
                         if (lastMemoryIdSetting != null) {
                             lastMemoryIdSetting.value = "" + memoryId;
@@ -1337,8 +1338,10 @@ public class MainActivity extends AppCompatActivity {
                             lastMemoryIdSetting = new AppSetting(AppSetting.SETTING_LAST_MEMORY_ID, "" + memoryId);
                             viewModel.getAppDb().appSettingDao().insertAll(lastMemoryIdSetting);
                         }
-                    }
-                });
+                    });
+                } catch (RejectedExecutionException ignored) {
+                    Log.d("DEBUG", "Skipping last-memory persistence because MainActivity is tearing down.");
+                }
                 return;
             }
         }

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
@@ -1642,7 +1642,9 @@ public class MainActivity extends AppCompatActivity {
 
     private final BroadcastReceiver usbReceiver = new BroadcastReceiver() {
         public void onReceive(Context context, Intent intent) {
-            Log.d("DEBUG", "usbReceiver.onReceive()");
+            Thread thread = Thread.currentThread();
+            Log.d("DEBUG", "usbReceiver.onReceive() action=" + intent.getAction()
+                + " thread=" + thread.getName() + "#" + thread.getId());
 
             String action = intent.getAction();
             synchronized (this) {

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
@@ -1826,9 +1826,7 @@ public class MainActivity extends AppCompatActivity {
                 }
                 break;
             case REQUEST_SETTINGS:
-                if (resultCode == Activity.RESULT_OK) {
-                    viewModel.loadDataAsync(this::applySettings);
-                }
+                viewModel.loadDataAsync(this::applySettings);
                 break;
             case REQUEST_FIRMWARE:
                 if (resultCode == Activity.RESULT_OK) {

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
@@ -301,7 +301,7 @@ public class MainActivity extends AppCompatActivity {
         filter.addAction(ACTION_USB_PERMISSION);
         filter.addAction(UsbManager.ACTION_USB_DEVICE_ATTACHED);
         filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);
-        registerReceiver(usbReceiver, filter);
+        registerReceiver(usbReceiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED);
         registerReceiver(serviceShutdownReceiver, new IntentFilter(RadioAudioService.ACTION_SERVICE_STOPPING), ContextCompat.RECEIVER_NOT_EXPORTED);
         viewModel.loadDataAsync(this::applySettings);
     }

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
@@ -298,6 +298,7 @@ public class MainActivity extends AppCompatActivity {
         });
         attachListeners();
         IntentFilter filter = new IntentFilter();
+        filter.addAction(ACTION_USB_PERMISSION);
         filter.addAction(UsbManager.ACTION_USB_DEVICE_ATTACHED);
         filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);
         registerReceiver(usbReceiver, filter);
@@ -1646,6 +1647,14 @@ public class MainActivity extends AppCompatActivity {
             String action = intent.getAction();
             synchronized (this) {
                 if (ACTION_USB_PERMISSION.equals(action) || UsbManager.ACTION_USB_DEVICE_ATTACHED.equals(action)) {
+                    if (ACTION_USB_PERMISSION.equals(action)
+                        && !intent.getBooleanExtra(UsbManager.EXTRA_PERMISSION_GRANTED, false)) {
+                        Log.w("DEBUG", "USB permission denied by user.");
+                        if (radioAudioService != null) {
+                            radioAudioService.onUsbPermissionDenied();
+                        }
+                        return;
+                    }
                     if (radioAudioService != null) {
                         radioAudioService.reconnectViaUSB();
                     }

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
@@ -302,7 +302,7 @@ public class MainActivity extends AppCompatActivity {
         filter.addAction(UsbManager.ACTION_USB_DEVICE_ATTACHED);
         filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);
         ContextCompat.registerReceiver(this, usbReceiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED);
-        registerReceiver(serviceShutdownReceiver, new IntentFilter(RadioAudioService.ACTION_SERVICE_STOPPING), Context.RECEIVER_NOT_EXPORTED);
+        ContextCompat.registerReceiver(this, serviceShutdownReceiver, new IntentFilter(RadioAudioService.ACTION_SERVICE_STOPPING), ContextCompat.RECEIVER_NOT_EXPORTED);
         viewModel.loadDataAsync(this::applySettings);
     }
 

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/SettingsActivity.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/SettingsActivity.java
@@ -217,7 +217,7 @@ public class SettingsActivity extends AppCompatActivity {
     }
 
     public void doneButtonClicked(View view) {
-        setResult(Activity.RESULT_OK, getIntent());
+        setResult(Activity.RESULT_OK);
         finish();
     }
 


### PR DESCRIPTION
  ### Why

  The previous event-based flow (start, USB attach/detach, run-error callbacks) could overlap and race, causing repeated connect attempts, flaky handshakes, and noisy UI behavior.

  ### What changed

  - Replaced event-triggered reconnect orchestration with periodic connection polling.
  - Added ConnectionController to centralize retry timing and attempt gating.
  - RadioAudioService now delegates connect scheduling to the controller and focuses on transport/handshake operations.

  May fix: https://github.com/VanceVagell/kv4p-ht/issues/378 and https://github.com/VanceVagell/kv4p-ht/pull/379#issuecomment-3963407571
