### PR TITLE
Fix: remove I2S 2% oversample causing 5Hz RX audio click

### DIFF
--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/rxAudio.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/rxAudio.h
@@ -95,7 +95,7 @@ void initI2SRx() {
   config.use_apll = true;
   config.auto_clear = false;
   config.adc_pin = hw.pins.pinAudioIn;
-  config.sample_rate = AUDIO_SAMPLE_RATE * 1.02; // 2% over sample rate to avoid buffer underruns
+  config.sample_rate = AUDIO_SAMPLE_RATE; // Use exact rate — APLL provides precise clock
   in.begin(config);
   rxEnc.setAudioInfo(rxInfo);
   // configure OPUS additinal parameters


### PR DESCRIPTION
## Summary

- Remove the `* 1.02` I2S sample rate multiplier in `rxAudio.h` that causes a periodic 5Hz clicking artifact in RX audio
- The APLL (`use_apll = true`) already provides a precise clock, making the oversample unnecessary

## Problem

The I2S ADC runs at 48,960 Hz while the Opus encoder consumes at 48,000 Hz. Every 200ms (~5 Opus frames), 192 extra samples accumulate and cause a buffer discontinuity that Opus encodes as an audible click.

## Evidence

Raw Opus capture analysis (bypassing all host processing):
- 2,501 sample discontinuities >1000 per 2 seconds
- 5Hz dominant artifact in envelope spectrum
- DC offset jumps up to 288 at Opus frame boundaries

See issue #388 for full analysis methodology and data.

## Test plan

- [ ] Build and flash patched firmware
- [ ] Compare raw Opus decode before/after for discontinuity count
- [ ] Verify no I2S buffer underruns (the original reason for the oversample)
- [ ] Confirm voice audio quality improvement by listening test

🤖 Generated with [Claude Code](https://claude.com/claude-code)