### PR TITLE
Use standard KISS TNC transport for serial protocol

### DIFF
--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/data/AppSetting.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/data/AppSetting.java
@@ -27,19 +27,11 @@ import lombok.Getter;
 @Entity(tableName = "app_settings")
 public class AppSetting {
     public static final String SETTING_LAST_GROUP = "lastGroup";
-    public static final String SETTING_LAST_MEMORY_ID = "lastMemoryId";
-    public static final String SETTING_LAST_FREQ = "lastFreq";
     public static final String SETTING_MIN_2_M_TX_FREQ = "min2mTxFreq";
     public static final String SETTING_MAX_2_M_TX_FREQ = "max2mTxFreq";
     public static final String SETTING_MIN_70_CM_TX_FREQ = "min70cmTxFreq";
     public static final String SETTING_MAX_70_CM_TX_FREQ = "max70cmTxFreq";
-    public static final String SETTING_RF_POWER = "rfPower";
-    public static final String SETTING_BANDWIDTH = "bandwidth";
     public static final String SETTING_MIC_GAIN_BOOST = "micGainBoost";
-    public static final String SETTING_SQUELCH = "squelch";
-    public static final String SETTING_EMPHASIS = "emphasis";
-    public static final String SETTING_HIGHPASS = "highpass";
-    public static final String SETTING_LOWPASS = "lowpass";
     public static final String SETTING_DISABLE_ANIMATIONS = "disableAnimations";
     public static final String SETTING_APRS_POSITION_ACCURACY = "aprsPositionAccuracy";
     public static final String SETTING_APRS_BEACON_POSITION = "aprsBeaconPosition";

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/Protocol.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/Protocol.java
@@ -95,16 +95,8 @@ public final class Protocol {
     @Getter
     public enum SndCommand {
         COMMAND_SND_UNKNOWN(0x00),
-        COMMAND_HOST_PTT_DOWN(0x01), // [COMMAND_HOST_PTT_DOWN()]
-        COMMAND_HOST_PTT_UP(0x02),   // [COMMAND_HOST_PTT_UP()]
-        COMMAND_HOST_GROUP(0x03),    // [COMMAND_HOST_GROUP(Group)]
-        COMMAND_HOST_FILTERS(0x04),  // [COMMAND_HOST_FILTERS(Filters)]
-        COMMAND_HOST_STOP(0x05),     // [COMMAND_HOST_STOP()]
-        COMMAND_HOST_CONFIG(0x06),   // [COMMAND_HOST_CONFIG(Config)] -> [COMMAND_VERSION(Version)]
         COMMAND_HOST_TX_AUDIO(0x07), // [COMMAND_HOST_TX_AUDIO(byte[])]
-        COMMAND_HOST_HL(0x08),       // [COMMAND_HOST_HL(Hl)]
-        COMMAND_HOST_RSSI(0x09),     // [COMMAND_HOST_RSSI(ON)]
-        COMMAND_HOST_TX_AX25(0x0A);  // Internal dispatch for KISS DATA AX.25 frames.
+        COMMAND_HOST_DESIRED_STATE(0x0D);
         private final int value;
         SndCommand(int value) {
             this.value = value;
@@ -114,19 +106,15 @@ public final class Protocol {
     @Getter
     public enum RcvCommand {
         COMMAND_RCV_UNKNOWN(0x00),
-        COMMAND_SMETER_REPORT( 0x53),   // [COMMAND_SMETER_REPORT(Rssi)]
-        COMMAND_PHYS_PTT_DOWN(0x44),    // [COMMAND_PHYS_PTT_DOWN()]
-        COMMAND_PHYS_PTT_UP(0x55),      // [COMMAND_PHYS_PTT_UP()]
         COMMAND_DEBUG_INFO(0x01),       // [COMMAND_DEBUG_INFO(char[])]
         COMMAND_DEBUG_ERROR(0x02),      // [COMMAND_DEBUG_ERROR(char[])]
         COMMAND_DEBUG_WARN(0x03),       // [COMMAND_DEBUG_WARN(char[])]
         COMMAND_DEBUG_DEBUG(0x04),      // [COMMAND_DEBUG_DEBUG(char[])]
         COMMAND_DEBUG_TRACE(0x05),      // [COMMAND_DEBUG_TRACE(char[])]
-        COMMAND_HELLO(0x06),            // [COMMAND_HELLO()]
+        COMMAND_HELLO(0x06),            // [COMMAND_HELLO(Hello)]
         COMMAND_RX_AUDIO(0x07),         // [COMMAND_RX_AUDIO(int8_t[])]
-        COMMAND_VERSION(0x08),          // [COMMAND_VERSION(Version)]
         COMMAND_WINDOW_UPDATE(0x09),    // [COMMAND_WINDOW_UPDATE()]
-        COMMAND_RX_AX25_PACKET(0x0A);   // Internal dispatch for KISS DATA AX.25 frames.
+        COMMAND_DEVICE_STATE(0x0B);
         private final int value;
         RcvCommand(int value) {
             this.value = value;
@@ -160,43 +148,68 @@ public final class Protocol {
         }
     }
 
-    @Data
-    @Builder
-    public static class Config {
-        private final boolean isHigh;
-        public byte[] toBytes() {
-            byte[] bytes = new byte[1];
-            bytes[0] = isHigh ? (byte) 0x01 : (byte) 0x00;
-            return bytes;
+    static final int HOST_STATE_RADIO_CONFIG_VALID = 1 << 0;
+    static final int HOST_STATE_PTT_REQUESTED = 1 << 1;
+    static final int HOST_STATE_RX_AUDIO_OPEN = 1 << 2;
+    static final int HOST_STATE_HIGH_POWER = 1 << 3;
+    static final int HOST_STATE_RSSI_ENABLED = 1 << 4;
+    static final int HOST_STATE_FILTER_PRE = 1 << 5;
+    static final int HOST_STATE_FILTER_HIGH = 1 << 6;
+    static final int HOST_STATE_FILTER_LOW = 1 << 7;
+    static final int DEVICE_STATE_PHYS_PTT_DOWN = 1 << 8;
+    static final int DEVICE_STATE_TX_ACTIVE = 1 << 9;
+    static final int DEVICE_STATE_SQUELCHED = 1 << 10;
+
+    @Getter
+    public enum DeviceMode {
+        DEVICE_MODE_TX(0),
+        DEVICE_MODE_RX(1),
+        DEVICE_MODE_STOPPED(2),
+        DEVICE_MODE_UNKNOWN(255);
+        private final int value;
+        DeviceMode(int value) {
+            this.value = value;
+        }
+        public static DeviceMode fromValue(int value) {
+            for (DeviceMode mode : DeviceMode.values()) {
+                if (mode.getValue() == value) {
+                    return mode;
+                }
+            }
+            return DEVICE_MODE_UNKNOWN;
         }
     }
 
     @Data
     @Builder
-    public static class Filters {
-        private final boolean pre;
-        private final boolean high;
-        private final boolean low;
-        public byte[] toBytes() {
-            byte result = 0;
-            if (pre) result |= 0x01;
-            if (high) result |= 0x02;
-            if (low) result |= 0x04;
-            return new byte[]{result};
-        }
-    }
+    public static class HostDesiredState {
+        static final int BYTE_LEN = 18;
+        private int sequence;
+        private int flags;
+        private byte bw;
+        private float freqTx;
+        private float freqRx;
+        private byte ctcssTx;
+        private byte squelch;
+        private byte ctcssRx;
 
-    @Data
-    @Builder
-    public static class Group {
-        private final byte bw;
-        private final float freqTx;
-        private final float freqRx;
-        private final byte ctcssTx;
-        private final byte squelch;
-        private final byte ctcssRx;
+        public HostDesiredState copy() {
+            return HostDesiredState.builder()
+                .sequence(sequence)
+                .flags(flags)
+                .bw(bw)
+                .freqTx(freqTx)
+                .freqRx(freqRx)
+                .ctcssTx(ctcssTx)
+                .squelch(squelch)
+                .ctcssRx(ctcssRx)
+                .build();
+        }
+
         public byte[] toBytes() {
-            ByteBuffer buffer = ByteBuffer.allocate(12).order(ByteOrder.LITTLE_ENDIAN);
+            ByteBuffer buffer = ByteBuffer.allocate(BYTE_LEN).order(ByteOrder.LITTLE_ENDIAN);
+            buffer.putInt(sequence);
+            buffer.putShort((short) flags);
             buffer.put(bw);
             buffer.putFloat(freqTx);
             buffer.putFloat(freqRx);
@@ -209,21 +222,42 @@ public final class Protocol {
 
     @Data
     @Builder
-    public static class HlState {
-        private final boolean isHighPower;
-        public byte[] toBytes() {
-            byte result = isHighPower ? (byte) 0x01 : (byte) 0x00;
-            return new byte[]{result};
+    public static class DeviceState {
+        static final int BYTE_LEN = 22;
+        private final int appliedSequence;
+        private final int flags;
+        private final byte bw;
+        private final float freqTx;
+        private final float freqRx;
+        private final byte ctcssTx;
+        private final byte squelch;
+        private final byte ctcssRx;
+        private final RadioStatus radioModuleStatus;
+        private final DeviceMode mode;
+        private final int lastError;
+        private final int latestRssi;
+        public static Optional<DeviceState> from(final byte[] param, Integer len) {
+            return from(param, 0, len);
         }
-    }
-
-    @Data
-    @Builder
-    public static class RSSIState {
-        private final boolean on;
-        public byte[] toBytes() {
-            byte result = on ? (byte) 0x01 : (byte) 0x00;
-            return new byte[]{result};
+        public static Optional<DeviceState> from(final byte[] param, int offset, Integer len) {
+            return Optional.ofNullable(param)
+                .filter(p -> len != null && len == BYTE_LEN && offset >= 0 && p.length >= offset + len)
+                .map(p -> ByteBuffer.wrap(p, offset, len))
+                .map(b -> b.order(ByteOrder.LITTLE_ENDIAN))
+                .map(b -> DeviceState.builder()
+                    .appliedSequence(b.getInt())
+                    .flags(b.getShort() & 0xFFFF)
+                    .bw(b.get())
+                    .freqTx(b.getFloat())
+                    .freqRx(b.getFloat())
+                    .ctcssTx(b.get())
+                    .squelch(b.get())
+                    .ctcssRx(b.get())
+                    .radioModuleStatus(RadioStatus.fromValue((char) b.get()))
+                    .mode(DeviceMode.fromValue(b.get() & 0xFF))
+                    .lastError(b.get() & 0xFF)
+                    .latestRssi(b.get() & 0xFF)
+                    .build());
         }
     }
 
@@ -245,35 +279,25 @@ public final class Protocol {
         }
     }
 
-    @Data
-    @Builder
-    public static class Rssi {
-        private final int sMeter9Value;
-        public static Optional<Rssi> from(final byte[] param, Integer len) {
-            return Optional.ofNullable(param)
-                .filter(p -> len != null && len == 1 && p.length >= len)
-                .map(p -> p[0] & 0xFF)
-                .map(Rssi::calculateSMeter9Value)
-                .map(rssi -> Rssi.builder().sMeter9Value(rssi).build());
-        }
-        private static int calculateSMeter9Value(int sMeter255Value) {
-            double result = 9.73 * Math.log(0.0297 * sMeter255Value) - 1.88;
-            return Math.max(1, Math.min(9, (int) Math.round(result)));
-        }
+    public static int calculateSMeter9Value(int sMeter255Value) {
+        double result = 9.73 * Math.log(0.0297 * sMeter255Value) - 1.88;
+        return Math.max(1, Math.min(9, (int) Math.round(result)));
     }
 
     @Data
     @Builder
     public static class FirmwareVersion {
+        private static final int BYTE_LEN = 12;
         private final short ver;  // equivalent to uint16_t
         private final RadioStatus radioModuleStatus;  // equivalent to char
         private final int windowSize; // equivalent to size_t
         private final RfModuleType moduleType;
         private final boolean hasHl;
         private final boolean hasPhysPtt;
+        private final DeviceState deviceState;
         public static Optional<FirmwareVersion> from(final byte[] param, Integer len) {
             return Optional.ofNullable(param)
-                .filter(p -> len != null && len == 12 && p.length >= len)
+                .filter(p -> len != null && len >= BYTE_LEN && p.length >= len)
                 .map(ByteBuffer::wrap)
                 .map(b -> b.order(ByteOrder.LITTLE_ENDIAN))
                 .map(b -> {
@@ -282,6 +306,10 @@ public final class Protocol {
                     int windowSize = b.getInt();
                     RfModuleType moduleType = RfModuleType.fromValue(b.getInt());
                     int features = b.get() & 0xFF;
+                    DeviceState deviceState = null;
+                    if (len >= BYTE_LEN + DeviceState.BYTE_LEN) {
+                        deviceState = DeviceState.from(param, BYTE_LEN, DeviceState.BYTE_LEN).orElse(null);
+                    }
                     return FirmwareVersion.builder()
                         .ver(ver)
                         .radioModuleStatus(radioModuleStatus)
@@ -289,6 +317,7 @@ public final class Protocol {
                         .moduleType(moduleType)
                         .hasHl((features & 0x01) != 0)
                         .hasPhysPtt((features & 0x02) != 0)
+                        .deviceState(deviceState)
                         .build();
                 });
         }
@@ -343,30 +372,6 @@ public final class Protocol {
             sendKissFrame(KISS_CMD_DATA, payload);
         }
 
-        public void pttDown() {
-            sendKv4pVendorFrame(SndCommand.COMMAND_HOST_PTT_DOWN, null);
-        }
-
-        public void pttUp() {
-            sendKv4pVendorFrame(SndCommand.COMMAND_HOST_PTT_UP, null);
-        }
-
-        public void group(Group group) {
-            sendKv4pVendorFrame(SndCommand.COMMAND_HOST_GROUP, group.toBytes());
-        }
-
-        public void filters(Filters filters) {
-            sendKv4pVendorFrame(SndCommand.COMMAND_HOST_FILTERS, filters.toBytes());
-        }
-
-        public void stop() {
-            sendKv4pVendorFrame(SndCommand.COMMAND_HOST_STOP, null);
-        }
-
-        public void config(Config config) {
-            sendKv4pVendorFrame(SndCommand.COMMAND_HOST_CONFIG, config.toBytes());
-        }
-
         public void txAudio(byte[] audio) {
             sendKv4pVendorFrame(SndCommand.COMMAND_HOST_TX_AUDIO, audio);
         }
@@ -415,18 +420,19 @@ public final class Protocol {
             }
         }
 
-        public void setHighPower(HlState state) {
-            sendKv4pVendorFrame(SndCommand.COMMAND_HOST_HL, state.toBytes());
-        }
-
-        public void setRssi(RSSIState state) {
-            sendKv4pVendorFrame(SndCommand.COMMAND_HOST_RSSI, state.toBytes());
+        public void sendDesiredState(HostDesiredState state) {
+            sendKv4pVendorFrame(SndCommand.COMMAND_HOST_DESIRED_STATE, state.toBytes());
         }
     }
 
     @FunctionalInterface
     public interface TriConsumer<T, U, V> {
         void accept(T t, U u, V v);
+    }
+
+    @FunctionalInterface
+    public interface PayloadConsumer {
+        void accept(byte[] payload, Integer len);
     }
 
     public static class KissParser {
@@ -438,9 +444,11 @@ public final class Protocol {
         private boolean dropFrame = false;
         private boolean inFrame = false;
         private final TriConsumer<RcvCommand, byte[], Integer> onCommand;
+        private final PayloadConsumer onAx25;
 
-        public KissParser(TriConsumer<RcvCommand, byte[], Integer> onCommand) {
+        public KissParser(TriConsumer<RcvCommand, byte[], Integer> onCommand, PayloadConsumer onAx25) {
             this.onCommand = onCommand;
+            this.onAx25 = onAx25;
         }
 
         public void processBytes(byte[] newData) {
@@ -497,10 +505,7 @@ public final class Protocol {
             }
             if (kissCommand == KISS_CMD_DATA) {
                 if (payloadLen > 0 && payloadLen <= PROTO_MTU) {
-                    onCommand.accept(
-                        RcvCommand.COMMAND_RX_AX25_PACKET,
-                        Arrays.copyOfRange(frame, 1, frameLen),
-                        payloadLen);
+                    onAx25.accept(Arrays.copyOfRange(frame, 1, frameLen), payloadLen);
                 }
             } else if (kissCommand == KISS_CMD_SETHARDWARE) {
                 processVendorFrame(payloadLen);

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/Protocol.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/Protocol.java
@@ -183,8 +183,9 @@ public final class Protocol {
     @Data
     @Builder
     public static class HostDesiredState {
-        static final int BYTE_LEN = 18;
+        static final int BYTE_LEN = 22;
         private int sequence;
+        private int memoryId;
         private int flags;
         private byte bw;
         private float freqTx;
@@ -196,6 +197,7 @@ public final class Protocol {
         public HostDesiredState copy() {
             return HostDesiredState.builder()
                 .sequence(sequence)
+                .memoryId(memoryId)
                 .flags(flags)
                 .bw(bw)
                 .freqTx(freqTx)
@@ -209,6 +211,7 @@ public final class Protocol {
         public byte[] toBytes() {
             ByteBuffer buffer = ByteBuffer.allocate(BYTE_LEN).order(ByteOrder.LITTLE_ENDIAN);
             buffer.putInt(sequence);
+            buffer.putInt(memoryId);
             buffer.putShort((short) flags);
             buffer.put(bw);
             buffer.putFloat(freqTx);
@@ -223,8 +226,9 @@ public final class Protocol {
     @Data
     @Builder
     public static class DeviceState {
-        static final int BYTE_LEN = 22;
+        static final int BYTE_LEN = 26;
         private final int appliedSequence;
+        private final int memoryId;
         private final int flags;
         private final byte bw;
         private final float freqTx;
@@ -236,6 +240,11 @@ public final class Protocol {
         private final DeviceMode mode;
         private final int lastError;
         private final int latestRssi;
+
+        public boolean hasRadioConfig() {
+            return (flags & HOST_STATE_RADIO_CONFIG_VALID) != 0;
+        }
+
         public static Optional<DeviceState> from(final byte[] param, Integer len) {
             return from(param, 0, len);
         }
@@ -246,6 +255,7 @@ public final class Protocol {
                 .map(b -> b.order(ByteOrder.LITTLE_ENDIAN))
                 .map(b -> DeviceState.builder()
                     .appliedSequence(b.getInt())
+                    .memoryId(b.getInt())
                     .flags(b.getShort() & 0xFFFF)
                     .bw(b.get())
                     .freqTx(b.getFloat())
@@ -287,11 +297,13 @@ public final class Protocol {
     @Data
     @Builder
     public static class FirmwareVersion {
-        private static final int BYTE_LEN = 12;
+        private static final int BYTE_LEN = 20;
         private final short ver;  // equivalent to uint16_t
         private final RadioStatus radioModuleStatus;  // equivalent to char
         private final int windowSize; // equivalent to size_t
         private final RfModuleType moduleType;
+        private final float minRadioFreq;
+        private final float maxRadioFreq;
         private final boolean hasHl;
         private final boolean hasPhysPtt;
         private final DeviceState deviceState;
@@ -305,6 +317,8 @@ public final class Protocol {
                     RadioStatus radioModuleStatus = RadioStatus.fromValue((char) b.get());
                     int windowSize = b.getInt();
                     RfModuleType moduleType = RfModuleType.fromValue(b.getInt());
+                    float minRadioFreq = b.getFloat();
+                    float maxRadioFreq = b.getFloat();
                     int features = b.get() & 0xFF;
                     DeviceState deviceState = null;
                     if (len >= BYTE_LEN + DeviceState.BYTE_LEN) {
@@ -315,6 +329,8 @@ public final class Protocol {
                         .radioModuleStatus(radioModuleStatus)
                         .windowSize(windowSize)
                         .moduleType(moduleType)
+                        .minRadioFreq(minRadioFreq)
+                        .maxRadioFreq(maxRadioFreq)
                         .hasHl((features & 0x01) != 0)
                         .hasPhysPtt((features & 0x02) != 0)
                         .deviceState(deviceState)

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/Protocol.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/Protocol.java
@@ -44,22 +44,32 @@ public final class Protocol {
     private Protocol() {
     }
 
+    private static int boundedPayloadLen(byte[] payload, int len) {
+        if (payload == null || len <= 0) {
+            return 0;
+        }
+        return Math.min(len, Math.min(payload.length, PROTO_MTU));
+    }
+
     static byte[] buildKissFrame(int kissCommand, byte[] payload) {
-        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        return buildKissFrame(kissCommand, payload, payload != null ? payload.length : 0);
+    }
+
+    static byte[] buildKissFrame(int kissCommand, byte[] payload, int len) {
+        int payloadLen = boundedPayloadLen(payload, len);
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream(payloadLen + 3);
         buffer.write(KISS_FEND);
         buffer.write(kissCommand & 0xFF);
-        if (payload != null) {
-            for (byte rawByte : payload) {
-                int b = rawByte & 0xFF;
-                if (b == KISS_FEND) {
-                    buffer.write(KISS_FESC);
-                    buffer.write(KISS_TFEND);
-                } else if (b == KISS_FESC) {
-                    buffer.write(KISS_FESC);
-                    buffer.write(KISS_TFESC);
-                } else {
-                    buffer.write(b);
-                }
+        for (int i = 0; i < payloadLen; i++) {
+            int b = payload[i] & 0xFF;
+            if (b == KISS_FEND) {
+                buffer.write(KISS_FESC);
+                buffer.write(KISS_TFEND);
+            } else if (b == KISS_FESC) {
+                buffer.write(KISS_FESC);
+                buffer.write(KISS_TFESC);
+            } else {
+                buffer.write(b);
             }
         }
         buffer.write(KISS_FEND);
@@ -67,7 +77,11 @@ public final class Protocol {
     }
 
     static byte[] buildKv4pVendorPayload(int kv4pCommand, byte[] param) {
-        int paramLen = param != null ? Math.min(param.length, PROTO_MTU) : 0;
+        return buildKv4pVendorPayload(kv4pCommand, param, param != null ? param.length : 0);
+    }
+
+    static byte[] buildKv4pVendorPayload(int kv4pCommand, byte[] param, int len) {
+        int paramLen = boundedPayloadLen(param, len);
         ByteBuffer payload = ByteBuffer.allocate(KV4P_VENDOR_HEADER_LEN + paramLen);
         payload.put(KV4P_VENDOR_PREFIX);
         payload.put((byte) KV4P_PROTOCOL_VERSION);
@@ -305,7 +319,11 @@ public final class Protocol {
         }
 
         private void sendKissFrame(int kissCommand, byte[] payload) {
-            byte[] frame = Protocol.buildKissFrame(kissCommand, payload);
+            sendKissFrame(kissCommand, payload, payload != null ? payload.length : 0);
+        }
+
+        private void sendKissFrame(int kissCommand, byte[] payload, int len) {
+            byte[] frame = Protocol.buildKissFrame(kissCommand, payload, len);
             int frameSize = frame.length;
             waitUntilCanSend(frameSize);
             usbIoManager.writeAsync(frame);
@@ -313,7 +331,11 @@ public final class Protocol {
         }
 
         private void sendKv4pVendorFrame(SndCommand commandType, byte[] param) {
-            sendKissFrame(KISS_CMD_SETHARDWARE, buildKv4pVendorPayload(commandType.getValue(), param));
+            sendKv4pVendorFrame(commandType, param, param != null ? param.length : 0);
+        }
+
+        private void sendKv4pVendorFrame(SndCommand commandType, byte[] param, int len) {
+            sendKissFrame(KISS_CMD_SETHARDWARE, buildKv4pVendorPayload(commandType.getValue(), param, len));
         }
 
         private void sendKissDataFrame(byte[] ax25Bytes) {
@@ -347,6 +369,10 @@ public final class Protocol {
 
         public void txAudio(byte[] audio) {
             sendKv4pVendorFrame(SndCommand.COMMAND_HOST_TX_AUDIO, audio);
+        }
+
+        public void txAudio(byte[] audio, int len) {
+            sendKv4pVendorFrame(SndCommand.COMMAND_HOST_TX_AUDIO, audio, len);
         }
 
         public void txAx25(byte[] ax25Bytes) {
@@ -406,6 +432,7 @@ public final class Protocol {
     public static class KissParser {
 
         private final byte[] frame = new byte[KISS_MAX_FRAME_SIZE];
+        private final byte[] commandParams = new byte[PROTO_MTU];
         private int frameLen = 0;
         private boolean escape = false;
         private boolean dropFrame = false;
@@ -499,12 +526,16 @@ public final class Protocol {
             int command = frame[payloadOffset + 5] & 0xFF;
             int commandPayloadOffset = payloadOffset + KV4P_VENDOR_HEADER_LEN;
             int commandPayloadLen = payloadLen - KV4P_VENDOR_HEADER_LEN;
+            if (commandPayloadLen > commandParams.length) {
+                return;
+            }
             RcvCommand cmd = RcvCommand.fromValue(command);
             if (cmd == RcvCommand.COMMAND_RCV_UNKNOWN) {
                 Log.w(TAG, "Unknown KV4P vendor cmd received from ESP32: 0x" + Integer.toHexString(command) + " paramLen=" + commandPayloadLen);
                 return;
             }
-            onCommand.accept(cmd, Arrays.copyOfRange(frame, commandPayloadOffset, commandPayloadOffset + commandPayloadLen), commandPayloadLen);
+            System.arraycopy(frame, commandPayloadOffset, commandParams, 0, commandPayloadLen);
+            onCommand.accept(cmd, commandParams, commandPayloadLen);
         }
 
         private void resetParser() {

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/Protocol.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/Protocol.java
@@ -2,6 +2,8 @@ package com.vagell.kv4pht.radio;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Condition;
@@ -18,16 +20,62 @@ import lombok.Getter;
 public final class Protocol {
     private static final String TAG = Protocol.class.getSimpleName();
 
-    // Delimiter must match ESP32 code
-    static final byte[] COMMAND_DELIMITER = new byte[]{(byte) 0xDE, (byte) 0xAD, (byte) 0xBE, (byte) 0xEF};
+    public static final int PROTO_MTU = 2048; // Maximum length of the frame
+
+    // KV4P KISS transport. Standard KISS DATA frames carry AX.25 packets.
+    // kv4p-specific commands are carried in KISS SETHARDWARE vendor frames:
+    // FEND 0x06 "KV4P" 0x01 <kv4pCommand> <payload...> FEND.
+    static final int KISS_FEND = 0xC0;
+    static final int KISS_FESC = 0xDB;
+    static final int KISS_TFEND = 0xDC;
+    static final int KISS_TFESC = 0xDD;
+    static final int KISS_CMD_DATA = 0x00;
+    static final int KISS_CMD_SETHARDWARE = 0x06;
+    static final int KISS_PORT_0 = 0x00;
+    static final int KV4P_PROTOCOL_VERSION = 0x01;
+    static final byte[] KV4P_VENDOR_PREFIX = new byte[]{'K', 'V', '4', 'P'};
+    static final int KV4P_VENDOR_HEADER_LEN = KV4P_VENDOR_PREFIX.length + 2; // "KV4P" + version + kv4pCommand
+    static final int KISS_MAX_FRAME_SIZE = PROTO_MTU + 1 + KV4P_VENDOR_HEADER_LEN;
 
     public static final byte DRA818_25K = 0x01;
     public static final byte DRA818_12K5 = 0x00;
 
-    public static final int PROTO_MTU = 2048; // Maximum length of the frame
-
 
     private Protocol() {
+    }
+
+    static byte[] buildKissFrame(int kissCommand, byte[] payload) {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        buffer.write(KISS_FEND);
+        buffer.write(kissCommand & 0xFF);
+        if (payload != null) {
+            for (byte rawByte : payload) {
+                int b = rawByte & 0xFF;
+                if (b == KISS_FEND) {
+                    buffer.write(KISS_FESC);
+                    buffer.write(KISS_TFEND);
+                } else if (b == KISS_FESC) {
+                    buffer.write(KISS_FESC);
+                    buffer.write(KISS_TFESC);
+                } else {
+                    buffer.write(b);
+                }
+            }
+        }
+        buffer.write(KISS_FEND);
+        return buffer.toByteArray();
+    }
+
+    static byte[] buildKv4pVendorPayload(int kv4pCommand, byte[] param) {
+        int paramLen = param != null ? Math.min(param.length, PROTO_MTU) : 0;
+        ByteBuffer payload = ByteBuffer.allocate(KV4P_VENDOR_HEADER_LEN + paramLen);
+        payload.put(KV4P_VENDOR_PREFIX);
+        payload.put((byte) KV4P_PROTOCOL_VERSION);
+        payload.put((byte) kv4pCommand);
+        if (paramLen > 0) {
+            payload.put(param, 0, paramLen);
+        }
+        return payload.array();
     }
 
     @Getter
@@ -42,7 +90,7 @@ public final class Protocol {
         COMMAND_HOST_TX_AUDIO(0x07), // [COMMAND_HOST_TX_AUDIO(byte[])]
         COMMAND_HOST_HL(0x08),       // [COMMAND_HOST_HL(Hl)]
         COMMAND_HOST_RSSI(0x09),     // [COMMAND_HOST_RSSI(ON)]
-        COMMAND_HOST_TX_AX25(0x0A);  // [COMMAND_HOST_TX_AX25(byte[])]
+        COMMAND_HOST_TX_AX25(0x0A);  // Internal dispatch for KISS DATA AX.25 frames.
         private final int value;
         SndCommand(int value) {
             this.value = value;
@@ -64,7 +112,7 @@ public final class Protocol {
         COMMAND_RX_AUDIO(0x07),         // [COMMAND_RX_AUDIO(int8_t[])]
         COMMAND_VERSION(0x08),          // [COMMAND_VERSION(Version)]
         COMMAND_WINDOW_UPDATE(0x09),    // [COMMAND_WINDOW_UPDATE()]
-        COMMAND_RX_AX25_PACKET(0x0A);   // [COMMAND_RX_AX25_PACKET(uint8_t decoderId, uint8_t[])]
+        COMMAND_RX_AX25_PACKET(0x0A);   // Internal dispatch for KISS DATA AX.25 frames.
         private final int value;
         RcvCommand(int value) {
             this.value = value;
@@ -189,7 +237,7 @@ public final class Protocol {
         private final int sMeter9Value;
         public static Optional<Rssi> from(final byte[] param, Integer len) {
             return Optional.ofNullable(param)
-                .filter(p -> len == 1)
+                .filter(p -> len != null && len == 1 && p.length >= len)
                 .map(p -> p[0] & 0xFF)
                 .map(Rssi::calculateSMeter9Value)
                 .map(rssi -> Rssi.builder().sMeter9Value(rssi).build());
@@ -211,17 +259,24 @@ public final class Protocol {
         private final boolean hasPhysPtt;
         public static Optional<FirmwareVersion> from(final byte[] param, Integer len) {
             return Optional.ofNullable(param)
-                .filter(p -> len == 12)
+                .filter(p -> len != null && len == 12 && p.length >= len)
                 .map(ByteBuffer::wrap)
                 .map(b -> b.order(ByteOrder.LITTLE_ENDIAN))
-                .map(b -> FirmwareVersion.builder()
-                    .ver(b.getShort())
-                    .radioModuleStatus(RadioStatus.fromValue((char) b.get()))
-                    .windowSize(b.getInt())
-                    .moduleType(RfModuleType.fromValue(b.getInt()))
-                    .hasHl((b.get() & 0x01) != 0)
-                    .hasPhysPtt((b.get() & 0x02) != 0)
-                    .build());
+                .map(b -> {
+                    short ver = b.getShort();
+                    RadioStatus radioModuleStatus = RadioStatus.fromValue((char) b.get());
+                    int windowSize = b.getInt();
+                    RfModuleType moduleType = RfModuleType.fromValue(b.getInt());
+                    int features = b.get() & 0xFF;
+                    return FirmwareVersion.builder()
+                        .ver(ver)
+                        .radioModuleStatus(radioModuleStatus)
+                        .windowSize(windowSize)
+                        .moduleType(moduleType)
+                        .hasHl((features & 0x01) != 0)
+                        .hasPhysPtt((features & 0x02) != 0)
+                        .build();
+                });
         }
     }
 
@@ -231,7 +286,7 @@ public final class Protocol {
         private final int size;
         public static Optional<WindowUpdate> from(final byte[] param, Integer len) {
             return Optional.ofNullable(param)
-                .filter(p -> len == 4)
+                .filter(p -> len != null && len == 4 && p.length >= len)
                 .map(ByteBuffer::wrap)
                 .map(b -> b.order(ByteOrder.LITTLE_ENDIAN))
                 .map(b -> WindowUpdate.builder().size(b.getInt()).build());
@@ -249,53 +304,53 @@ public final class Protocol {
             this.usbIoManager = usbIoManager;
         }
 
-        private void sendCommand(SndCommand commandType, byte[] param) {
-            int frameSize = COMMAND_DELIMITER.length + 1 + 2 + (param != null ? param.length : 0);
+        private void sendKissFrame(int kissCommand, byte[] payload) {
+            byte[] frame = Protocol.buildKissFrame(kissCommand, payload);
+            int frameSize = frame.length;
             waitUntilCanSend(frameSize);
-            ByteBuffer buffer = ByteBuffer.allocate(frameSize);
-            buffer.order(ByteOrder.LITTLE_ENDIAN);
-            buffer.put(COMMAND_DELIMITER);
-            buffer.put((byte) commandType.getValue());
-            if (param != null) {
-                buffer.putShort((short) param.length);
-                buffer.put(param);
-            } else {
-                buffer.putShort((short) 0);
-            }
-            usbIoManager.writeAsync(buffer.array());
+            usbIoManager.writeAsync(frame);
             flowControlWindow.addAndGet(-frameSize);
         }
 
+        private void sendKv4pVendorFrame(SndCommand commandType, byte[] param) {
+            sendKissFrame(KISS_CMD_SETHARDWARE, buildKv4pVendorPayload(commandType.getValue(), param));
+        }
+
+        private void sendKissDataFrame(byte[] ax25Bytes) {
+            byte[] payload = ax25Bytes == null ? new byte[0] : Arrays.copyOf(ax25Bytes, Math.min(ax25Bytes.length, PROTO_MTU));
+            sendKissFrame(KISS_CMD_DATA, payload);
+        }
+
         public void pttDown() {
-            sendCommand(SndCommand.COMMAND_HOST_PTT_DOWN, null);
+            sendKv4pVendorFrame(SndCommand.COMMAND_HOST_PTT_DOWN, null);
         }
 
         public void pttUp() {
-            sendCommand(SndCommand.COMMAND_HOST_PTT_UP, null);
+            sendKv4pVendorFrame(SndCommand.COMMAND_HOST_PTT_UP, null);
         }
 
         public void group(Group group) {
-            sendCommand(SndCommand.COMMAND_HOST_GROUP, group.toBytes());
+            sendKv4pVendorFrame(SndCommand.COMMAND_HOST_GROUP, group.toBytes());
         }
 
         public void filters(Filters filters) {
-            sendCommand(SndCommand.COMMAND_HOST_FILTERS, filters.toBytes());
+            sendKv4pVendorFrame(SndCommand.COMMAND_HOST_FILTERS, filters.toBytes());
         }
 
         public void stop() {
-            sendCommand(SndCommand.COMMAND_HOST_STOP, null);
+            sendKv4pVendorFrame(SndCommand.COMMAND_HOST_STOP, null);
         }
 
         public void config(Config config) {
-            sendCommand(SndCommand.COMMAND_HOST_CONFIG, config.toBytes());
+            sendKv4pVendorFrame(SndCommand.COMMAND_HOST_CONFIG, config.toBytes());
         }
 
         public void txAudio(byte[] audio) {
-            sendCommand(SndCommand.COMMAND_HOST_TX_AUDIO, audio);
+            sendKv4pVendorFrame(SndCommand.COMMAND_HOST_TX_AUDIO, audio);
         }
 
         public void txAx25(byte[] ax25Bytes) {
-            sendCommand(SndCommand.COMMAND_HOST_TX_AX25, ax25Bytes);
+            sendKissDataFrame(ax25Bytes);
         }
         
         // Waits until it can send (windowSize > 0)
@@ -335,11 +390,11 @@ public final class Protocol {
         }
 
         public void setHighPower(HlState state) {
-            sendCommand(SndCommand.COMMAND_HOST_HL, state.toBytes());
+            sendKv4pVendorFrame(SndCommand.COMMAND_HOST_HL, state.toBytes());
         }
 
         public void setRssi(RSSIState state) {
-            sendCommand(SndCommand.COMMAND_HOST_RSSI, state.toBytes());
+            sendKv4pVendorFrame(SndCommand.COMMAND_HOST_RSSI, state.toBytes());
         }
     }
 
@@ -348,16 +403,16 @@ public final class Protocol {
         void accept(T t, U u, V v);
     }
 
-    public static class FrameParser {
+    public static class KissParser {
 
-        private int matchedDelimiterTokens = 0;
-        private byte command;
-        private int commandParamLen;
-        private final byte[] commandParams = new byte[PROTO_MTU];
-        private int paramIndex;
+        private final byte[] frame = new byte[KISS_MAX_FRAME_SIZE];
+        private int frameLen = 0;
+        private boolean escape = false;
+        private boolean dropFrame = false;
+        private boolean inFrame = false;
         private final TriConsumer<RcvCommand, byte[], Integer> onCommand;
 
-        public FrameParser(TriConsumer<RcvCommand, byte[], Integer> onCommand) {
+        public KissParser(TriConsumer<RcvCommand, byte[], Integer> onCommand) {
             this.onCommand = onCommand;
         }
 
@@ -368,50 +423,95 @@ public final class Protocol {
         }
 
         private void processByte(byte b) {
-            if (matchedDelimiterTokens < COMMAND_DELIMITER.length) {
-                matchedDelimiterTokens = (b == COMMAND_DELIMITER[matchedDelimiterTokens]) ? matchedDelimiterTokens + 1 : 0;
-            } else if (matchedDelimiterTokens == COMMAND_DELIMITER.length) {
-                command = b;
-                matchedDelimiterTokens++;
-            } else if (matchedDelimiterTokens == COMMAND_DELIMITER.length + 1) {
-                commandParamLen = b & 0xFF;
-                matchedDelimiterTokens++;
-            } else if (matchedDelimiterTokens == COMMAND_DELIMITER.length + 2) {
-                commandParamLen = (b & 0xFF) << 8 | commandParamLen;
-                paramIndex = 0;
-                matchedDelimiterTokens++;
-                if (commandParamLen == 0) {
-                    processCommand();
-                    resetParser();
+            int value = b & 0xFF;
+            if (value == KISS_FEND) {
+                if (frameLen > 0 && !dropFrame) {
+                    processFrame();
                 }
-                if (commandParamLen > commandParams.length) {
-                    resetParser();
+                resetParser();
+                inFrame = true;
+            } else if (!inFrame) {
+                return;
+            } else if (dropFrame) {
+                return;
+            } else if (escape) {
+                if (value == KISS_TFEND) {
+                    appendByte((byte) KISS_FEND);
+                } else if (value == KISS_TFESC) {
+                    appendByte((byte) KISS_FESC);
+                } else {
+                    // Unknown KISS escape: drop this frame and wait for the next FEND.
+                    dropFrame = true;
                 }
+                escape = false;
+            } else if (value == KISS_FESC) {
+                escape = true;
             } else {
-                if (paramIndex < commandParamLen) {
-                    commandParams[paramIndex++] = b;
-                }
-                matchedDelimiterTokens++;
-                if (paramIndex == commandParamLen) {
-                    processCommand();
-                    resetParser();
-                }
+                appendByte(b);
             }
         }
 
-        private void processCommand() {
-            RcvCommand cmd = RcvCommand.fromValue(this.command);
-            if (cmd != RcvCommand.COMMAND_RCV_UNKNOWN) {
-                onCommand.accept(cmd, commandParams, commandParamLen);
-            } else {
-                Log.w(TAG, "Unknown cmd received from ESP32: 0x" + Integer.toHexString(this.command & 0xFF) + " paramLen=" + commandParamLen);
+        private void appendByte(byte b) {
+            if (frameLen >= KISS_MAX_FRAME_SIZE) {
+                dropFrame = true;
+                return;
             }
+            frame[frameLen++] = b;
+        }
+
+        private void processFrame() {
+            int kissCommandByte = frame[0] & 0xFF;
+            int kissPort = kissCommandByte >> 4;
+            int kissCommand = kissCommandByte & 0x0F;
+            int payloadLen = frameLen - 1;
+
+            if (kissPort != KISS_PORT_0) {
+                return;
+            }
+            if (kissCommand == KISS_CMD_DATA) {
+                if (payloadLen > 0 && payloadLen <= PROTO_MTU) {
+                    onCommand.accept(
+                        RcvCommand.COMMAND_RX_AX25_PACKET,
+                        Arrays.copyOfRange(frame, 1, frameLen),
+                        payloadLen);
+                }
+            } else if (kissCommand == KISS_CMD_SETHARDWARE) {
+                processVendorFrame(payloadLen);
+            } else {
+                Log.w(TAG, "Unknown KISS cmd received from ESP32: 0x" + Integer.toHexString(kissCommand));
+            }
+        }
+
+        private void processVendorFrame(int payloadLen) {
+            if (payloadLen < KV4P_VENDOR_HEADER_LEN) {
+                return;
+            }
+            int payloadOffset = 1;
+            for (int i = 0; i < KV4P_VENDOR_PREFIX.length; i++) {
+                if (frame[payloadOffset + i] != KV4P_VENDOR_PREFIX[i]) {
+                    return;
+                }
+            }
+            if ((frame[payloadOffset + 4] & 0xFF) != KV4P_PROTOCOL_VERSION) {
+                return;
+            }
+
+            int command = frame[payloadOffset + 5] & 0xFF;
+            int commandPayloadOffset = payloadOffset + KV4P_VENDOR_HEADER_LEN;
+            int commandPayloadLen = payloadLen - KV4P_VENDOR_HEADER_LEN;
+            RcvCommand cmd = RcvCommand.fromValue(command);
+            if (cmd == RcvCommand.COMMAND_RCV_UNKNOWN) {
+                Log.w(TAG, "Unknown KV4P vendor cmd received from ESP32: 0x" + Integer.toHexString(command) + " paramLen=" + commandPayloadLen);
+                return;
+            }
+            onCommand.accept(cmd, Arrays.copyOfRange(frame, commandPayloadOffset, commandPayloadOffset + commandPayloadLen), commandPayloadLen);
         }
 
         private void resetParser() {
-            matchedDelimiterTokens = 0;
-            paramIndex = 0;
-            commandParamLen = 0;
+            frameLen = 0;
+            escape = false;
+            dropFrame = false;
+            inFrame = false;
         }
     }
 }

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/ProtocolHandshake.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/ProtocolHandshake.java
@@ -164,16 +164,11 @@ class ProtocolHandshake {
             }
             final Protocol.FirmwareVersion ver = firmwareVersion.get();
             Log.d(TAG, handshakeLog(handshakeId, "checkFirmwareVersionAndRadioStatus(): version=" + ver));
-            radioAudioService.getCallbacks().firmwareVersionReceived(ver.getVer());
             if (ver.getVer() < FirmwareUtils.PACKAGED_FIRMWARE_VER) {
                 radioAudioService.getCallbacks().outdatedFirmware(ver.getVer());
                 return HandshakeResult.TOO_OLD;
             }
-            radioAudioService.setRadioType(Protocol.RfModuleType.RF_SA818_VHF.equals(ver.getModuleType())
-                ? RadioAudioService.RadioModuleType.VHF
-                : RadioAudioService.RadioModuleType.UHF);
-            radioAudioService.setHasHighLowPowerSwitch(ver.isHasHl());
-            radioAudioService.setHasPhysPttButton(ver.isHasPhysPtt());
+            radioAudioService.handleFirmwareVersion(ver);
             if (Protocol.RadioStatus.RADIO_STATUS_NOT_FOUND.equals(ver.getRadioModuleStatus())) {
                 return HandshakeResult.RADIO_MODULE_NOT_FOUND;
             } else {
@@ -181,7 +176,7 @@ class ProtocolHandshake {
                 if (ver.getDeviceState() != null) {
                     radioAudioService.handleInitialDeviceState(ver.getDeviceState());
                 }
-                radioAudioService.applyRadioPreferencesToFirmware(ver.isHasHl());
+                radioAudioService.markRadioTransportReady();
                 return HandshakeResult.OK;
             }
         });

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/ProtocolHandshake.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/ProtocolHandshake.java
@@ -24,22 +24,20 @@ import com.vagell.kv4pht.firmware.FirmwareUtils;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 /**
- * Handles the asynchronous, multistep handshake process with the ESP32 over USB serial.
- * Steps include waiting for a HELLO command, sending configuration, and verifying firmware version.
+ * Handles the asynchronous handshake process with the ESP32 over USB serial.
+ * The firmware sends HELLO with version/status payload once radio initialization is complete.
  * This class supports clean chaining with timeouts, and can be restarted if the ESP32 reboots.
  */
 @SuppressWarnings({"javaarchitecture:S7027"})
 class ProtocolHandshake {
     private static final String TAG = ProtocolHandshake.class.getSimpleName();
-    private static final int HELLO_TIMEOUT_MS = 1500;
-    private static final int FIRMWARE_VERSION_TIMEOUT_MS = 60000;
+    private static final int HELLO_TIMEOUT_MS = 60000;
     private enum HandshakeResult {INVALID, TOO_OLD, OK, RADIO_MODULE_NOT_FOUND}
     private final RadioAudioService radioAudioService;
     private ScheduledExecutorService protocolScheduler = Executors.newSingleThreadScheduledExecutor();
@@ -47,13 +45,9 @@ class ProtocolHandshake {
     private int activeHandshakeId = 0;
 
     /**
-     * Future completed when HELLO is received or timeout occurs.
+     * Future completed when HELLO with version/status payload is received or timeout occurs.
      */
-    private @NonNull CompletableFuture<Void> waitForHello = CompletableFuture.completedFuture(null);
-    /**
-     * Future completed when firmware version is received or timeout occurs.
-     */
-    private @NonNull CompletableFuture<Optional<Protocol.FirmwareVersion>> waitFirmwareVersion =
+    private @NonNull CompletableFuture<Optional<Protocol.FirmwareVersion>> waitForHello =
         CompletableFuture.completedFuture(Optional.empty());
 
     public ProtocolHandshake(RadioAudioService radioAudioService) {
@@ -69,18 +63,17 @@ class ProtocolHandshake {
         }
         int handshakeId = ++handshakeSeq;
         activeHandshakeId = handshakeId;
-        Log.i(TAG, handshakeLog(handshakeId, "start(): waiting for HELLO"));
-        startFor(handshakeId, waitForHello(handshakeId)
-            .thenCompose(ignored -> sendConfigStep(handshakeId)));
+        radioAudioService.getCallbacks().radioModuleHandshake();
+        Log.i(TAG, handshakeLog(handshakeId, "start(): waiting for HELLO(version)"));
+        startFor(handshakeId, waitForHello(handshakeId));
     }
 
     public void onDestroy() {
         protocolScheduler.shutdownNow();
     }
 
-    private void startFor(int handshakeId, CompletionStage<Void> chain) {
-        chain
-            .thenCompose(ignored -> waitForFirmwareVersion(handshakeId))
+    private void startFor(int handshakeId, CompletableFuture<Optional<Protocol.FirmwareVersion>> waitHello) {
+        waitHello
             .thenCompose(version -> checkFirmwareVersionAndRadioStatus(handshakeId, version))
             .thenAccept(res -> handleResult(handshakeId, res))
             .exceptionally(ex -> {
@@ -98,8 +91,8 @@ class ProtocolHandshake {
     private void handleResult(int handshakeId, HandshakeResult res) {
         switch (res) {
             case INVALID:
-                Log.e(TAG, handshakeLog(handshakeId, "invalid FirmwareVersion packet"));
-                radioAudioService.getCallbacks().missingFirmware();
+                Log.e(TAG, handshakeLog(handshakeId, "HELLO missing valid FirmwareVersion payload; firmware upgrade required"));
+                radioAudioService.getCallbacks().outdatedFirmware(0);
                 radioAudioService.setMode(RadioMode.BAD_FIRMWARE);
                 return;
             case TOO_OLD:
@@ -112,8 +105,9 @@ class ProtocolHandshake {
                 radioAudioService.getCallbacks().radioModuleNotFound();
                 return;
             case OK:
-                Log.i(TAG, handshakeLog(handshakeId, "firmware version OK; proceeding with radio communication"));
+                Log.i(TAG, handshakeLog(handshakeId, "HELLO version OK; proceeding with radio communication"));
                 radioAudioService.setMode(RadioMode.RX);
+                radioAudioService.openFirmwareAudio();
                 // Turn off scanning if it was on (e.g. if radio was unplugged briefly and reconnected)
                 radioAudioService.setScanning(false);
                 radioAudioService.radioConnected();
@@ -123,31 +117,17 @@ class ProtocolHandshake {
     /**
      * Called when a HELLO command is received from the ESP32.
      * If a handshake is already waiting for HELLO, complete it.
-     * If no handshake is active (e.g., due to unexpected reboot), restart the handshake from config step.
+     * If no handshake is active (e.g., due to unexpected reboot), validate the new HELLO payload.
      */
-    public void onHelloReceived() {
+    public void onHelloReceived(Optional<Protocol.FirmwareVersion> version) {
         if (!waitForHello.isDone()) {
-            Log.d(TAG, handshakeLog(activeHandshakeId, "HELLO received"));
-            waitForHello.complete(null);
+            Log.d(TAG, handshakeLog(activeHandshakeId, "HELLO received: " + version));
+            waitForHello.complete(version);
         } else {
             int handshakeId = ++handshakeSeq;
             activeHandshakeId = handshakeId;
-            Log.i(TAG, handshakeLog(handshakeId, "HELLO received after wait completed; restarting from config step"));
-            startFor(handshakeId, sendConfigStep(handshakeId)); // ESP32 rebooted mid-session, restart from config step
-        }
-    }
-
-    /**
-     * Notifies the handshake logic that a firmware version was received from the ESP32.
-     * Completes the waiting future if it's active.
-     *
-     * @param version The firmware version parsed from the received data.
-     * @noinspection OptionalUsedAsFieldOrParameterType
-     */
-    public void onVersionReceived(Optional<Protocol.FirmwareVersion> version) {
-        if (!waitFirmwareVersion.isDone()) {
-            Log.d(TAG, handshakeLog(activeHandshakeId, "firmware version received: " + version));
-            waitFirmwareVersion.complete(version);
+            Log.i(TAG, handshakeLog(handshakeId, "HELLO received after wait completed; validating rebooted firmware"));
+            startFor(handshakeId, CompletableFuture.completedFuture(version));
         }
     }
 
@@ -156,7 +136,7 @@ class ProtocolHandshake {
      *
      * @return A future that completes when HELLO is received or times out.
      */
-    private CompletableFuture<Void> waitForHello(int handshakeId) {
+    private CompletableFuture<Optional<Protocol.FirmwareVersion>> waitForHello(int handshakeId) {
         waitForHello = new CompletableFuture<>();
         Log.d(TAG, handshakeLog(handshakeId, "waitForHello(): timeout=" + HELLO_TIMEOUT_MS + "ms"));
         protocolScheduler.schedule(() -> {
@@ -166,40 +146,6 @@ class ProtocolHandshake {
             }
         }, HELLO_TIMEOUT_MS, TimeUnit.MILLISECONDS);
         return waitForHello;
-    }
-
-    /**
-     * Sends configuration to the ESP32.
-     * Stops any previous communication, notifies callbacks, and sends power config.
-     *
-     * @return A future that completes once the config is sent.
-     */
-    private CompletableFuture<Void> sendConfigStep(int handshakeId) {
-        return CompletableFuture.runAsync(() -> {
-            radioAudioService.getCallbacks().radioModuleHandshake();
-            radioAudioService.setMode(RadioMode.STARTUP);
-            radioAudioService.getHostToEsp32().stop();
-            Protocol.Config cfg = Protocol.Config.builder().isHigh(radioAudioService.isHighPower()).build();
-            Log.d(TAG, handshakeLog(handshakeId, "sendConfigStep(): sending " + cfg));
-            radioAudioService.getHostToEsp32().config(cfg);
-        });
-    }
-
-    /**
-     * Waits for a firmware version response from the ESP32 with a timeout.
-     *
-     * @return A future that completes when version is received or times out.
-     */
-    private CompletableFuture<Optional<Protocol.FirmwareVersion>> waitForFirmwareVersion(int handshakeId) {
-        waitFirmwareVersion = new CompletableFuture<>();
-        Log.d(TAG, handshakeLog(handshakeId, "waitForFirmwareVersion(): timeout=" + FIRMWARE_VERSION_TIMEOUT_MS + "ms"));
-        protocolScheduler.schedule(() -> {
-            if (!waitFirmwareVersion.isDone()) {
-                Log.w(TAG, handshakeLog(handshakeId, "waitForFirmwareVersion(): timed out"));
-                waitFirmwareVersion.completeExceptionally(new TimeoutException("Timeout waiting for firmware version"));
-            }
-        }, FIRMWARE_VERSION_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-        return waitFirmwareVersion;
     }
 
     /**
@@ -213,7 +159,7 @@ class ProtocolHandshake {
     private CompletableFuture<HandshakeResult> checkFirmwareVersionAndRadioStatus(int handshakeId, Optional<Protocol.FirmwareVersion> firmwareVersion) {
         return CompletableFuture.supplyAsync(() -> {
             if (!firmwareVersion.isPresent()) {
-                Log.w(TAG, handshakeLog(handshakeId, "checkFirmwareVersionAndRadioStatus(): no firmware version present"));
+                Log.w(TAG, handshakeLog(handshakeId, "checkFirmwareVersionAndRadioStatus(): HELLO has no valid version payload"));
                 return HandshakeResult.INVALID;
             }
             final Protocol.FirmwareVersion ver = firmwareVersion.get();
@@ -232,6 +178,10 @@ class ProtocolHandshake {
                 return HandshakeResult.RADIO_MODULE_NOT_FOUND;
             } else {
                 radioAudioService.getHostToEsp32().setFlowControlWindow(ver.getWindowSize());
+                if (ver.getDeviceState() != null) {
+                    radioAudioService.handleInitialDeviceState(ver.getDeviceState());
+                }
+                radioAudioService.applyRadioPreferencesToFirmware(ver.isHasHl());
                 return HandshakeResult.OK;
             }
         });

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
@@ -87,6 +87,7 @@ import com.vagell.kv4pht.ui.MainActivity;
 import com.vagell.kv4pht.ui.ToneHelper;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.*;
 import java.util.concurrent.*;
@@ -1201,23 +1202,23 @@ public class RadioAudioService extends Service {
     private void handleParsedCommand(final RcvCommand cmd, final byte[] param, final Integer len) {
         switch (cmd) {
             case COMMAND_DEBUG_INFO:
-                Log.i(FIRMWARE_TAG, new String(Arrays.copyOf(param, len)));
+                Log.i(FIRMWARE_TAG, firmwareString(param, len));
                 break;
 
             case COMMAND_DEBUG_DEBUG:
-                Log.d(FIRMWARE_TAG, new String(Arrays.copyOf(param, len)));
+                Log.d(FIRMWARE_TAG, firmwareString(param, len));
                 break;
 
             case COMMAND_DEBUG_ERROR:
-                Log.e(FIRMWARE_TAG, new String(Arrays.copyOf(param, len)));
+                Log.e(FIRMWARE_TAG, firmwareString(param, len));
                 break;
 
             case COMMAND_DEBUG_WARN:
-                Log.w(FIRMWARE_TAG, new String(Arrays.copyOf(param, len)));
+                Log.w(FIRMWARE_TAG, firmwareString(param, len));
                 break;
 
             case COMMAND_DEBUG_TRACE:
-                Log.v(FIRMWARE_TAG, new String(Arrays.copyOf(param, len)));
+                Log.v(FIRMWARE_TAG, firmwareString(param, len));
                 break;
 
             case COMMAND_HELLO:
@@ -1240,6 +1241,11 @@ public class RadioAudioService extends Service {
             default:
                 break;
         }
+    }
+
+    private String firmwareString(byte[] param, Integer len) {
+        int safeLen = param == null || len == null ? 0 : Math.min(len, param.length);
+        return new String(param, 0, safeLen, StandardCharsets.UTF_8);
     }
 
     private void handleEsp32Ax25Packet(final byte[] param, final Integer len) {

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
@@ -81,7 +81,7 @@ import com.vagell.kv4pht.data.ChannelMemory;
 import com.vagell.kv4pht.javAX25.ax25.Arrays;
 import com.vagell.kv4pht.javAX25.ax25.Packet;
 import com.vagell.kv4pht.radio.Protocol.Filters;
-import com.vagell.kv4pht.radio.Protocol.FrameParser;
+import com.vagell.kv4pht.radio.Protocol.KissParser;
 import com.vagell.kv4pht.radio.Protocol.Group;
 import com.vagell.kv4pht.radio.Protocol.HlState;
 import com.vagell.kv4pht.radio.Protocol.RcvCommand;
@@ -186,7 +186,7 @@ public class RadioAudioService extends Service {
     private boolean usbPermissionRequestPending = false;
     @Getter
     private Protocol.Sender hostToEsp32;
-    private final FrameParser esp32DataStreamParser = new FrameParser(this::handleParsedCommand);
+    private final KissParser esp32DataStreamParser = new KissParser(this::handleParsedCommand);
     private int usbConnectAttemptSeq = 0;
     private int activeUsbConnectAttemptId = 0;
 
@@ -1228,10 +1228,10 @@ public class RadioAudioService extends Service {
     }
 
     private void handleEsp32Ax25Packet(final byte[] param, final Integer len) {
-        if (param == null || len == null || len < 2) {
+        if (param == null || len == null || len < 1) {
             return;
         }
-        handleAx25Packet(java.util.Arrays.copyOfRange(param, 1, len));
+        handleAx25Packet(java.util.Arrays.copyOf(param, len));
     }
 
     private void handlePhysicalPttUp() {

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
@@ -80,10 +80,7 @@ import com.vagell.kv4pht.aprs.parser.PositionField;
 import com.vagell.kv4pht.data.ChannelMemory;
 import com.vagell.kv4pht.javAX25.ax25.Arrays;
 import com.vagell.kv4pht.javAX25.ax25.Packet;
-import com.vagell.kv4pht.radio.Protocol.Filters;
 import com.vagell.kv4pht.radio.Protocol.KissParser;
-import com.vagell.kv4pht.radio.Protocol.Group;
-import com.vagell.kv4pht.radio.Protocol.HlState;
 import com.vagell.kv4pht.radio.Protocol.RcvCommand;
 import com.vagell.kv4pht.radio.Protocol.WindowUpdate;
 import com.vagell.kv4pht.ui.MainActivity;
@@ -187,7 +184,8 @@ public class RadioAudioService extends Service {
     private boolean usbPermissionRequestPending = false;
     @Getter
     private Protocol.Sender hostToEsp32;
-    private final KissParser esp32DataStreamParser = new KissParser(this::handleParsedCommand);
+    private RadioModuleController radioModule;
+    private final KissParser esp32DataStreamParser = new KissParser(this::handleParsedCommand, this::handleEsp32Ax25Packet);
     private int usbConnectAttemptSeq = 0;
     private int activeUsbConnectAttemptId = 0;
 
@@ -209,9 +207,7 @@ public class RadioAudioService extends Service {
     @Getter
     @Setter
     private boolean hasPhysPttButton = false;
-    @Getter
     private boolean isHighPower = true;
-    @Getter
     private boolean isRssiOn = true;
     @Getter
     private boolean txAllowed = true;
@@ -224,7 +220,7 @@ public class RadioAudioService extends Service {
     @Getter
     private RadioModuleType radioType = RadioModuleType.UNKNOWN;
     private int activeMemoryId = -1;
-    private int consecutiveSilenceBytes = 0;
+    private long scanSquelchedSinceMs = -1L;
     private MicGainBoost micGainBoost = MicGainBoost.NONE;
     @Setter
     private @NonNull String bandwidth = "25kHz";
@@ -386,7 +382,7 @@ public class RadioAudioService extends Service {
 
     public void setMode(RadioMode mode) {
         if (mode == RadioMode.FLASHING) {
-            hostToEsp32.stop();
+            Optional.ofNullable(radioModule).ifPresent(RadioModuleController::stop);
             audioTrack.stop();
             usbIoManager.stop();
             try {
@@ -404,7 +400,28 @@ public class RadioAudioService extends Service {
             }
         }
 
+        RadioMode previousMode = this.mode;
         this.mode = mode;
+        if (previousMode != mode) {
+            syncFirmwareAudioStateForMode(mode);
+        }
+    }
+
+    private void syncFirmwareAudioStateForMode(RadioMode mode) {
+        if (!isConnectionReady()) {
+            return;
+        }
+        if (mode == RadioMode.RX || mode == RadioMode.SCAN) {
+            openFirmwareAudio();
+        } else if (mode == RadioMode.STARTUP || mode == RadioMode.BAD_FIRMWARE || mode == RadioMode.UNKNOWN) {
+            radioModule.closeAudio();
+        }
+    }
+
+    void openFirmwareAudio() {
+        if (isConnectionReady()) {
+            radioModule.openAudio();
+        }
     }
 
     public void setActiveMemoryId(int activeMemoryId) {
@@ -577,7 +594,7 @@ public class RadioAudioService extends Service {
         if (isConnectionReady() && (mode == RadioMode.RX || mode == RadioMode.TX || mode == RadioMode.SCAN)) {
             try {
                 Log.d(TAG, "Sending stop to ESP32...");
-                hostToEsp32.stop();
+                radioModule.closeAudio();
                 Thread.sleep(100);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
@@ -603,11 +620,7 @@ public class RadioAudioService extends Service {
     }
 
     private void setRadioFilters(boolean emphasis, boolean highpass, boolean lowpass) {
-        hostToEsp32.filters(Filters.builder()
-            .high(highpass)
-            .low(lowpass)
-            .pre(emphasis)
-            .build());
+        radioModule.setFilters(emphasis, highpass, lowpass);
     }
 
     /**
@@ -643,12 +656,17 @@ public class RadioAudioService extends Service {
         activeMemoryId = -1; // Reset active memory ID since we're tuning to a frequency, not a memory.
         squelch = squelchLevel;
         if (isRadioConnected()) {
-            hostToEsp32.group(Group.builder()
-                .freqTx(freq)
-                .freqRx(freq)
-                .bw((bandwidth.equals("25kHz") ? DRA818_25K : DRA818_12K5))
-                .squelch((byte) squelchLevel)
-                .build());
+            radioModule.beginUpdate();
+            try {
+                radioModule.setBandwidth(bandwidth.equals("25kHz") ? DRA818_25K : DRA818_12K5);
+                radioModule.setTxFrequency(freq);
+                radioModule.setRxFrequency(freq);
+                radioModule.setTxTone((byte) 0);
+                radioModule.setSquelch((byte) squelchLevel);
+                radioModule.setRxTone((byte) 0);
+            } finally {
+                radioModule.endUpdate();
+            }
         }
         txAllowed = isTxAllowed(freq);
     }
@@ -695,14 +713,17 @@ public class RadioAudioService extends Service {
         activeMemoryId = memory.memoryId;
         final float txFreq = Float.parseFloat(getTxFreq(memory.frequency, memory.offset, memory.offsetKhz));
         if (isRadioConnected()) {
-            hostToEsp32.group(Group.builder()
-                .freqTx(txFreq)
-                .freqRx(Float.parseFloat(makeSafeHamFreq(activeFrequencyStr)))
-                .bw(bandwidth.equals("25kHz") ? DRA818_25K : DRA818_12K5)
-                .squelch((byte) squelchLevel)
-                .ctcssRx((byte) Math.max(0, ToneHelper.getToneIndex(memory.rxTone)))
-                .ctcssTx((byte) Math.max(0, ToneHelper.getToneIndex(memory.txTone)))
-                .build());
+            radioModule.beginUpdate();
+            try {
+                radioModule.setBandwidth(bandwidth.equals("25kHz") ? DRA818_25K : DRA818_12K5);
+                radioModule.setTxFrequency(txFreq);
+                radioModule.setRxFrequency(Float.parseFloat(makeSafeHamFreq(activeFrequencyStr)));
+                radioModule.setTxTone((byte) Math.max(0, ToneHelper.getToneIndex(memory.txTone)));
+                radioModule.setSquelch((byte) squelchLevel);
+                radioModule.setRxTone((byte) Math.max(0, ToneHelper.getToneIndex(memory.rxTone)));
+            } finally {
+                radioModule.endUpdate();
+            }
         }
         txAllowed = isTxAllowed(txFreq);
 
@@ -723,14 +744,21 @@ public class RadioAudioService extends Service {
         }
     }
 
-    private void checkScanDueToSilence() {
-        // Note that we handle scanning explicitly like this rather than using dra->scan() because
-        // as best I can tell the DRA818v chip has a defect where it always returns "S=1" (which
-        // means there is no signal detected on the given frequency) even when there is. I did
-        // extensive debugging and even rewrote large portions of the DRA818v library to determine
-        // that this was the case. So in lieu of that, we scan using a timing/silence-based system.
-        if (consecutiveSilenceBytes >= (AUDIO_SAMPLE_RATE * SEC_BETWEEN_SCANS)) {
-            consecutiveSilenceBytes = 0;
+    private void checkScanDueToSquelch() {
+        if (getMode() != RadioMode.SCAN || radioModule == null) {
+            scanSquelchedSinceMs = -1L;
+            return;
+        }
+        if (!radioModule.isSquelched()) {
+            scanSquelchedSinceMs = -1L;
+            return;
+        }
+        long nowMs = System.currentTimeMillis();
+        if (scanSquelchedSinceMs < 0) {
+            scanSquelchedSinceMs = nowMs;
+        }
+        if (nowMs - scanSquelchedSinceMs >= (long) (SEC_BETWEEN_SCANS * 1000L)) {
+            scanSquelchedSinceMs = -1L;
             nextScan();
         }
     }
@@ -788,7 +816,7 @@ public class RadioAudioService extends Service {
             setMode(RadioMode.TX);
             callbacks.sMeterUpdate(0);
             setTxRunAwayTimer();
-            hostToEsp32.pttDown();
+            radioModule.pttDown();
             audioTrackVolume = 0.0f;
             Optional.ofNullable(audioTrack).ifPresent(t -> t.setVolume(0.0f));
             callbacks.txStarted();
@@ -802,7 +830,7 @@ public class RadioAudioService extends Service {
             setMode(RadioMode.RX);
             audioTrackVolume = 0.0f;
             Optional.ofNullable(audioTrack).ifPresent(t -> t.setVolume(0.0f));
-            hostToEsp32.pttUp();
+            radioModule.pttUp();
             callbacks.txEnded();
         }
     }
@@ -829,11 +857,13 @@ public class RadioAudioService extends Service {
 
     private boolean isConnectionReady() {
         return hostToEsp32 != null
+            && radioModule != null
             && serialPort != null
             && usbIoManager != null;
     }
 
     private void closePortAndReset() {
+        radioModule = null;
         hostToEsp32 = null;
         if (usbIoManager != null) {
             try {
@@ -965,6 +995,7 @@ public class RadioAudioService extends Service {
         usbIoManager.setReadBufferCount(16 * 2);
         usbIoManager.start();
         hostToEsp32 = new Protocol.Sender(usbIoManager);
+        radioModule = new RadioModuleController(hostToEsp32);
         Log.i(TAG, connectLog("setupSerialConnection(): serial transport connected; starting handshake"));
         protocolHandshake.start();
     }
@@ -1051,8 +1082,11 @@ public class RadioAudioService extends Service {
         Log.d(TAG, "Max radio freq: " + maxRadioFreq);
         Log.d(TAG, "Min tx freq: " + minTxFreq);
         Log.d(TAG, "Max tx freq: " + maxTxFreq);
-        txAllowed = isTxAllowed(Float.parseFloat(activeFrequencyStr));
-        Log.d(TAG, String.format("Tx allowed: %b (%s)", txAllowed, activeFrequencyStr));
+        float txFrequency = radioModule != null && radioModule.getTxFrequency() > 0
+            ? radioModule.getTxFrequency()
+            : Float.parseFloat(activeFrequencyStr);
+        txAllowed = isTxAllowed(txFrequency);
+        Log.d(TAG, String.format("Tx allowed: %b (%s)", txAllowed, txFrequency));
     }
 
     public void setScanning(boolean scanning, boolean goToRxMode) {
@@ -1114,8 +1148,7 @@ public class RadioAudioService extends Service {
                 Log.d(TAG, "Memory with id " + candidate.memoryId + " had invalid frequency.");
             }
             if (!candidate.skipDuringScan && memoryFreqFloat >= minRadioFreq && memoryFreqFloat <= maxRadioFreq) {
-                // Reset silence since we found an active memory.
-                consecutiveSilenceBytes = 0;
+                scanSquelchedSinceMs = -1L;
                 // If squelch is off (0), use squelch=1 during scanning.
                 tuneToMemory(candidate, squelch > 0 ? squelch : 1, true);
                 callbacks.scannedToMemory(candidate.memoryId);
@@ -1167,21 +1200,6 @@ public class RadioAudioService extends Service {
     @SuppressWarnings({"java:S6541"})
     private void handleParsedCommand(final RcvCommand cmd, final byte[] param, final Integer len) {
         switch (cmd) {
-            case COMMAND_SMETER_REPORT:
-                Protocol.Rssi.from(param, len)
-                    .map(Protocol.Rssi::getSMeter9Value)
-                    .filter(i -> getMode() == RadioMode.RX || getMode() == RadioMode.SCAN)
-                    .ifPresent(callbacks::sMeterUpdate);
-                break;
-
-            case COMMAND_PHYS_PTT_DOWN:
-                handlePhysicalPttDown();
-                break;
-
-            case COMMAND_PHYS_PTT_UP:
-                handlePhysicalPttUp();
-                break;
-
             case COMMAND_DEBUG_INFO:
                 Log.i(FIRMWARE_TAG, new String(Arrays.copyOf(param, len)));
                 break;
@@ -1203,23 +1221,20 @@ public class RadioAudioService extends Service {
                 break;
 
             case COMMAND_HELLO:
-                protocolHandshake.onHelloReceived();
+                protocolHandshake.onHelloReceived(Protocol.FirmwareVersion.from(param, len));
                 break;
 
             case COMMAND_RX_AUDIO:
                 handleRxAudio(param, len);
                 break;
 
-            case COMMAND_VERSION:
-                protocolHandshake.onVersionReceived(Protocol.FirmwareVersion.from(param, len));
-                break;
-
             case COMMAND_WINDOW_UPDATE:
                 WindowUpdate.from(param, len).ifPresent(windowAck ->
                     hostToEsp32.enlargeFlowControlWindow(windowAck.getSize()));
                 break;
-            case COMMAND_RX_AX25_PACKET:
-                handleEsp32Ax25Packet(param, len);
+
+            case COMMAND_DEVICE_STATE:
+                Protocol.DeviceState.from(param, len).ifPresent(this::handleDeviceState);
                 break;
 
             default:
@@ -1234,24 +1249,44 @@ public class RadioAudioService extends Service {
         handleAx25Packet(java.util.Arrays.copyOf(param, len));
     }
 
-    private void handlePhysicalPttUp() {
-        if (getMode() == RadioMode.TX) {
-            endPtt();
-            callbacks.forcedPttEnd();
+    void handleInitialDeviceState(Protocol.DeviceState state) {
+        if (radioModule != null) {
+            radioModule.seedFromDeviceState(state);
         }
+        handleDeviceState(state);
     }
 
-    private void handlePhysicalPttDown() {
-        if (getMode() == RadioMode.RX && txAllowed) { // Note that people can't hit PTT in the middle of a scan.
-            startPtt();
-            callbacks.forcedPttStart();
+    private void handleDeviceState(Protocol.DeviceState state) {
+        Log.d(TAG, "Device state: " + state);
+        if (radioModule == null) {
+            return;
+        }
+        radioModule.updateDeviceState(state);
+        if (radioModule.isAppliedStateInSync() && radioModule.getTxFrequency() > 0) {
+            txAllowed = isTxAllowed(radioModule.getTxFrequency());
+        }
+        if (getMode() == RadioMode.RX || getMode() == RadioMode.SCAN) {
+            callbacks.sMeterUpdate(radioModule.getSMeter9Value());
+        }
+        checkScanDueToSquelch();
+        if (radioModule.didPhysPttChange()) {
+            boolean physPttDown = radioModule.isPhysPttDown();
+            if (physPttDown) {
+                if (getMode() == RadioMode.RX && txAllowed) {
+                    startPtt();
+                    callbacks.forcedPttStart();
+                }
+            } else if (getMode() == RadioMode.TX) {
+                endPtt();
+                callbacks.forcedPttEnd();
+            }
         }
     }
 
     /**
      * Handles incoming audio data from the ESP32, decoding it and playing it through the AudioTrack.
      * If in RX or SCAN mode, it processes the audio samples and manages the AFSK demodulator.
-     * In SCAN mode, it checks for silence to determine if a scan should be triggered.
+     * In SCAN mode, firmware squelch state determines whether scanning should advance.
      *
      * @param param The byte array containing the audio data.
      * @param len   The length of the audio data in bytes.
@@ -1264,16 +1299,6 @@ public class RadioAudioService extends Service {
             audioTrack.write(pcmFloat, 0, decoded, AudioTrack.WRITE_NON_BLOCKING);
             audioManager.requestAudioFocus(audioFocusRequest);
             ensureAudioPlaying();
-        }
-        if (getMode() == RadioMode.SCAN) {
-            for (int i = 0; i < decoded; i++) {
-                if (Math.abs(pcmFloat[i]) > 0.001) {
-                    consecutiveSilenceBytes = 0;
-                } else {
-                    consecutiveSilenceBytes++;
-                    checkScanDueToSilence();
-                }
-            }
         }
     }
 
@@ -1470,13 +1495,22 @@ public class RadioAudioService extends Service {
      * @param highPower true to enable high power mode, false to disable it.
      */
     public void setHighPower(boolean highPower) {
-        if (isHighPower != highPower) {
+        if (isHighPower() != highPower) {
             isHighPower = highPower;
-            if (isRadioConnected()) {
-                hostToEsp32.setHighPower(HlState.builder()
-                    .isHighPower(highPower)
-                    .build());
-            }
+            applyRadioPreferencesToFirmware(hasHighLowPowerSwitch);
+        }
+    }
+
+    public boolean isHighPower() {
+        return radioModule != null ? radioModule.isHighPowerEnabled() : isHighPower;
+    }
+
+    void applyRadioPreferencesToFirmware(boolean canSetHighPower) {
+        if (isConnectionReady() && canSetHighPower) {
+            radioModule.setHighPower(isHighPower);
+        }
+        if (isConnectionReady()) {
+            radioModule.setRssi(isRssiOn);
         }
     }
 
@@ -1491,13 +1525,15 @@ public class RadioAudioService extends Service {
      * @param on true to enable RSSI, false to disable it.
      */
     public void setRssi(boolean on) {
-        if (isRssiOn != on) {
+        if (isRssiOn() != on) {
             isRssiOn = on;
             if (isRadioConnected()) {
-                hostToEsp32.setRssi(Protocol.RSSIState.builder()
-                        .on(isRssiOn)
-                        .build());
+                radioModule.setRssi(isRssiOn);
             }
         }
+    }
+
+    public boolean isRssiOn() {
+        return radioModule != null ? radioModule.isRssiEnabled() : isRssiOn;
     }
 }

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
@@ -131,6 +131,7 @@ public class RadioAudioService extends Service {
     private static final String MESSAGE_NOTIFICATION_CHANNEL_ID = "aprs_message_notifications";
     private static final int MESSAGE_NOTIFICATION_TO_YOU_ID = 0;
     public static final List<Digipeater> DEFAULT_DIGIPEATERS = List.of(new Digipeater("WIDE1*"), new Digipeater("WIDE2-1"));
+    private static final long SCAN_SQUELCHED_ADVANCE_DELAY_MS = 250L;
 
     // === Used for the persistent notification ===
     private PowerManager.WakeLock wakeLock;
@@ -197,8 +198,9 @@ public class RadioAudioService extends Service {
     @Getter
     private @NonNull String activeFrequencyStr = "";
     private int activeMemoryId = -1;
-    private long scanSquelchedSinceMs = -1L;
     private int scanBaseSquelch = -1;
+    private Runnable pendingScanAdvance;
+    private int pendingScanAdvanceMemoryId = -1;
     private MicGainBoost micGainBoost = MicGainBoost.NONE;
 
     // === Android Components ===
@@ -215,9 +217,6 @@ public class RadioAudioService extends Service {
     private boolean radioMissingNotified = false;
     private Runnable txTimeoutHandler;
     private LiveData<List<ChannelMemory>> channelMemoriesLiveData = null;
-
-    // === Scan Timing ===
-    private static final float SEC_BETWEEN_SCANS = 0.5f;
 
     /**
      * Class used for the client Binder. This service always runs in the same process as its clients.
@@ -684,20 +683,40 @@ public class RadioAudioService extends Service {
 
     private void checkScanDueToSquelch() {
         if (getMode() != RadioMode.SCAN) {
-            scanSquelchedSinceMs = -1L;
+            cancelPendingScanAdvance();
             return;
         }
-        if (!radioModule.isSquelched()) {
-            scanSquelchedSinceMs = -1L;
+        if (radioModule.getMemoryId() == activeMemoryId && radioModule.isSquelched()) {
+            scheduleScanAdvance(activeMemoryId);
+        } else {
+            cancelPendingScanAdvance();
+        }
+    }
+
+    private void scheduleScanAdvance(int memoryId) {
+        if (pendingScanAdvance != null && pendingScanAdvanceMemoryId == memoryId) {
             return;
         }
-        long nowMs = System.currentTimeMillis();
-        if (scanSquelchedSinceMs < 0) {
-            scanSquelchedSinceMs = nowMs;
-        }
-        if (nowMs - scanSquelchedSinceMs >= (long) (SEC_BETWEEN_SCANS * 1000L)) {
-            scanSquelchedSinceMs = -1L;
-            nextScan();
+        cancelPendingScanAdvance();
+        pendingScanAdvanceMemoryId = memoryId;
+        pendingScanAdvance = () -> {
+            pendingScanAdvance = null;
+            pendingScanAdvanceMemoryId = -1;
+            if (getMode() == RadioMode.SCAN
+                && activeMemoryId == memoryId
+                && radioModule.getMemoryId() == memoryId
+                && radioModule.isSquelched()) {
+                nextScan();
+            }
+        };
+        handler.postDelayed(pendingScanAdvance, SCAN_SQUELCHED_ADVANCE_DELAY_MS);
+    }
+
+    private void cancelPendingScanAdvance() {
+        if (pendingScanAdvance != null) {
+            handler.removeCallbacks(pendingScanAdvance);
+            pendingScanAdvance = null;
+            pendingScanAdvanceMemoryId = -1;
         }
     }
 
@@ -1059,6 +1078,7 @@ public class RadioAudioService extends Service {
             return;
         }
         if (!scanning) {
+            cancelPendingScanAdvance();
             if (scanBaseSquelch >= 0 && scanBaseSquelch != radioModule.getDesiredSquelch()) {
                 radioModule.beginUpdate();
                 try {
@@ -1088,6 +1108,7 @@ public class RadioAudioService extends Service {
     }
 
     public void nextScan() {
+        cancelPendingScanAdvance();
         // Only proceed if actually in SCAN mode.
         if (getMode() != RadioMode.SCAN) {
             return;
@@ -1124,7 +1145,6 @@ public class RadioAudioService extends Service {
                 Log.d(TAG, "Memory with id " + candidate.memoryId + " had invalid frequency.");
             }
             if (!candidate.skipDuringScan && memoryFreqFloat >= getMinRadioFreq() && memoryFreqFloat <= getMaxRadioFreq()) {
-                scanSquelchedSinceMs = -1L;
                 // If squelch is off (0), use squelch=1 during scanning.
                 int desiredSquelch = scanBaseSquelch >= 0 ? scanBaseSquelch : radioModule.getDesiredSquelch();
                 radioModule.beginUpdate();

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
@@ -18,9 +18,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 package com.vagell.kv4pht.radio;
 
-import static com.vagell.kv4pht.radio.Protocol.DRA818_12K5;
-import static com.vagell.kv4pht.radio.Protocol.DRA818_25K;
-
 import android.Manifest;
 import android.app.Notification;
 import android.app.NotificationChannel;
@@ -135,12 +132,6 @@ public class RadioAudioService extends Service {
     private static final int MESSAGE_NOTIFICATION_TO_YOU_ID = 0;
     public static final List<Digipeater> DEFAULT_DIGIPEATERS = List.of(new Digipeater("WIDE1*"), new Digipeater("WIDE2-1"));
 
-    // === Frequency Ranges ===
-    private static final float VHF_MIN_FREQ = 134.0f;
-    private static final float VHF_MAX_FREQ = 174.0f;
-    private static final float UHF_MIN_FREQ = 400.0f;
-    private static final float UHF_MAX_FREQ = 480.0f;
-
     // === Used for the persistent notification ===
     private PowerManager.WakeLock wakeLock;
     private static final int SERVICE_ID = 1;
@@ -155,10 +146,6 @@ public class RadioAudioService extends Service {
     @Setter
     private float max70cmTxFreq = 450.0f;
 
-    @Getter
-    private float minRadioFreq = VHF_MIN_FREQ;
-    @Getter
-    private float maxRadioFreq = VHF_MAX_FREQ;
     @Setter
     private float minTxFreq = min2mTxFreq;
     @Setter
@@ -185,7 +172,8 @@ public class RadioAudioService extends Service {
     private boolean usbPermissionRequestPending = false;
     @Getter
     private Protocol.Sender hostToEsp32;
-    private RadioModuleController radioModule;
+    @Getter
+    private final RadioModuleController radioModule = new RadioModuleController();
     private final KissParser esp32DataStreamParser = new KissParser(this::handleParsedCommand, this::handleEsp32Ax25Packet);
     private int usbConnectAttemptSeq = 0;
     private int activeUsbConnectAttemptId = 0;
@@ -203,28 +191,15 @@ public class RadioAudioService extends Service {
     @Getter
     private @NonNull RadioMode mode = RadioMode.STARTUP;
     @Getter
-    @Setter
-    private boolean hasHighLowPowerSwitch = false;
-    @Getter
-    @Setter
-    private boolean hasPhysPttButton = false;
-    private boolean isHighPower = true;
-    private boolean isRssiOn = true;
-    @Getter
     private boolean txAllowed = true;
-    @Setter
-    private int squelch = 0;
     @Setter
     private @NonNull String callsign = "";
     @Getter
     private @NonNull String activeFrequencyStr = "";
-    @Getter
-    private RadioModuleType radioType = RadioModuleType.UNKNOWN;
     private int activeMemoryId = -1;
     private long scanSquelchedSinceMs = -1L;
+    private int scanBaseSquelch = -1;
     private MicGainBoost micGainBoost = MicGainBoost.NONE;
-    @Setter
-    private @NonNull String bandwidth = "25kHz";
 
     // === Android Components ===
     private final IBinder binder = new RadioBinder();
@@ -267,7 +242,7 @@ public class RadioAudioService extends Service {
         default void packetReceived(APRSPacket aprsPacket) {}
         default void scannedToMemory(int memoryId) {}
         default void outdatedFirmware(int firmwareVer) {}
-        default void firmwareVersionReceived(int firmwareVer) {}
+        default void initialDeviceStateReceived() {}
         default void missingFirmware() {}
         default void txStarted() {}
         default void txEnded() {}
@@ -293,36 +268,16 @@ public class RadioAudioService extends Service {
 
         // Retrieve necessary parameters from the intent.
         callsign = bundle.getString("callsign");
-        squelch = bundle.getInt("squelch");
+        if (bundle.containsKey("squelch")) {
+            radioModule.seedDesiredSquelch(bundle.getInt("squelch"));
+        }
         activeMemoryId = bundle.getInt("activeMemoryId");
         activeFrequencyStr = bundle.getString("activeFrequencyStr");
         return binder;
     }
 
-    public void setFilters(boolean emphasis, boolean highpass, boolean lowpass) {
-        setRadioFilters(emphasis, highpass, lowpass);
-    }
-
     public void setMicGainBoost(String micGainBoost) {
         this.micGainBoost = MicGainBoost.parse(micGainBoost);
-    }
-
-    public void setMinRadioFreq(float newMinFreq) {
-        minRadioFreq = newMinFreq;
-        // Detect if we're moving from VHF to UHF, and move active frequency to within band.
-        if (mode != RadioMode.STARTUP && Float.parseFloat(activeFrequencyStr) < minRadioFreq) {
-            tuneToFreq(String.format(java.util.Locale.US, "%.4f", min70cmTxFreq), squelch, true);
-            callbacks.forceTunedToFreq(activeFrequencyStr);
-        }
-    }
-
-    public void setMaxRadioFreq(float newMaxFreq) {
-        maxRadioFreq = newMaxFreq;
-        // Detect if we're moving from UHF to VHF, and move active frequency to within band.
-        if (mode != RadioMode.STARTUP && Float.parseFloat(activeFrequencyStr) > maxRadioFreq) {
-            tuneToFreq(String.format(java.util.Locale.US, "%.4f", min2mTxFreq), squelch, true);
-            callbacks.forceTunedToFreq(activeFrequencyStr);
-        }
     }
 
     public void setAprsBeaconPosition(boolean enabled) {
@@ -383,7 +338,7 @@ public class RadioAudioService extends Service {
 
     public void setMode(RadioMode mode) {
         if (mode == RadioMode.FLASHING) {
-            Optional.ofNullable(radioModule).ifPresent(RadioModuleController::stop);
+            radioModule.stop();
             audioTrack.stop();
             usbIoManager.stop();
             try {
@@ -428,9 +383,9 @@ public class RadioAudioService extends Service {
     public void setActiveMemoryId(int activeMemoryId) {
         this.activeMemoryId = activeMemoryId;
         if (activeMemoryId > -1) {
-            tuneToMemory(activeMemoryId, squelch, false);
+            tuneToMemory(activeMemoryId);
         } else {
-            tuneToFreq(activeFrequencyStr, squelch, false);
+            tuneToFreq(activeFrequencyStr);
         }
     }
 
@@ -620,10 +575,6 @@ public class RadioAudioService extends Service {
         notificationManager.createNotificationChannel(channel);
     }
 
-    private void setRadioFilters(boolean emphasis, boolean highpass, boolean lowpass) {
-        radioModule.setFilters(emphasis, highpass, lowpass);
-    }
-
     /**
      * Determines if transmission (TX) is allowed on the given frequency.
      *
@@ -631,20 +582,15 @@ public class RadioAudioService extends Service {
      * @return true if the frequency is within the allowed transmission range, false otherwise.
      */
     private boolean isTxAllowed(float freq) {
-        final float halfBandwidth = (bandwidth.equals("25kHz") ? 0.025f : 0.0125f) / 2;
+        final float halfBandwidth = radioModule.getHalfBandwidthMhz();
         return  (freq >= (minTxFreq + halfBandwidth)) && (freq <= (maxTxFreq - halfBandwidth));
     }
 
-    // Tell microcontroller to tune to the given frequency string, which must already be formatted
-    // in the style the radio module expects.
-    public void tuneToFreq(String frequencyStr, int squelchLevel, boolean forceTune) {
+    public void tuneToFreq(String frequencyStr) {
         if (mode == RadioMode.STARTUP) {
             return; // Not fully loaded and initialized yet, don't tune.
         }
         setMode(RadioMode.RX);
-        if (!forceTune && activeFrequencyStr.equals(frequencyStr) && squelch == squelchLevel) {
-            return; // Already tuned to this frequency with this squelch level.
-        }
         float freq;
         try {
             freq = Float.parseFloat(makeSafeHamFreq(frequencyStr));
@@ -655,19 +601,16 @@ public class RadioAudioService extends Service {
         }
         activeFrequencyStr = frequencyStr;
         activeMemoryId = -1; // Reset active memory ID since we're tuning to a frequency, not a memory.
-        squelch = squelchLevel;
-        if (isRadioConnected()) {
-            radioModule.beginUpdate();
-            try {
-                radioModule.setBandwidth(bandwidth.equals("25kHz") ? DRA818_25K : DRA818_12K5);
-                radioModule.setTxFrequency(freq);
-                radioModule.setRxFrequency(freq);
-                radioModule.setTxTone((byte) 0);
-                radioModule.setSquelch((byte) squelchLevel);
-                radioModule.setRxTone((byte) 0);
-            } finally {
-                radioModule.endUpdate();
-            }
+        radioModule.beginUpdate();
+        try {
+            radioModule.setMemoryId(-1);
+            radioModule.setVfoTones((byte) 0, (byte) 0);
+            radioModule.setTxFrequency(freq);
+            radioModule.setRxFrequency(freq);
+            radioModule.setTxTone((byte) 0);
+            radioModule.setRxTone((byte) 0);
+        } finally {
+            radioModule.endUpdate();
         }
         txAllowed = isTxAllowed(freq);
     }
@@ -679,7 +622,7 @@ public class RadioAudioService extends Service {
             while (freq > 500.0f) {
                 freq /= 10;
             }
-            return formatFreq(Math.max(minRadioFreq, Math.min(freq, maxRadioFreq)));
+            return formatFreq(Math.max(getMinRadioFreq(), Math.min(freq, getMaxRadioFreq())));
         } catch (NumberFormatException e) {
             return formatFreq(minTxFreq);
         }
@@ -694,40 +637,34 @@ public class RadioAudioService extends Service {
         return makeSafeHamFreq(tempFrequency);
     }
 
-    public void tuneToMemory(int memoryId, int squelchLevel, boolean forceTune) {
-        if (forceTune || activeMemoryId != memoryId || squelch != squelchLevel) {
-            Optional.ofNullable(channelMemoriesLiveData)
-                .map(LiveData::getValue)
-                .orElse(Collections.emptyList())
-                .stream()
-                .filter(channelMemory -> channelMemory.memoryId == memoryId)
-                .findFirst()
-                .ifPresent(channelMemory -> tuneToMemory(channelMemory, squelchLevel, forceTune));
-        }
+    public void tuneToMemory(int memoryId) {
+        Optional.ofNullable(channelMemoriesLiveData)
+            .map(LiveData::getValue)
+            .orElse(Collections.emptyList())
+            .stream()
+            .filter(channelMemory -> channelMemory.memoryId == memoryId)
+            .findFirst()
+            .ifPresent(this::tuneToMemory);
     }
 
-    public void tuneToMemory(ChannelMemory memory, int squelchLevel, boolean forceTune) {
-        if (memory == null || (!forceTune && activeMemoryId == memory.memoryId && squelch == squelchLevel) || mode == RadioMode.STARTUP) {
-            return; // Skip if memory is null, already tuned, or in STARTUP mode.
+    public void tuneToMemory(ChannelMemory memory) {
+        if (memory == null || mode == RadioMode.STARTUP) {
+            return;
         }
         activeFrequencyStr = validateFrequency(memory.frequency);
         activeMemoryId = memory.memoryId;
         final float txFreq = Float.parseFloat(getTxFreq(memory.frequency, memory.offset, memory.offsetKhz));
-        if (isRadioConnected()) {
-            radioModule.beginUpdate();
-            try {
-                radioModule.setBandwidth(bandwidth.equals("25kHz") ? DRA818_25K : DRA818_12K5);
-                radioModule.setTxFrequency(txFreq);
-                radioModule.setRxFrequency(Float.parseFloat(makeSafeHamFreq(activeFrequencyStr)));
-                radioModule.setTxTone((byte) Math.max(0, ToneHelper.getToneIndex(memory.txTone)));
-                radioModule.setSquelch((byte) squelchLevel);
-                radioModule.setRxTone((byte) Math.max(0, ToneHelper.getToneIndex(memory.rxTone)));
-            } finally {
-                radioModule.endUpdate();
-            }
+        radioModule.beginUpdate();
+        try {
+            radioModule.setMemoryId(memory.memoryId);
+            radioModule.setTxFrequency(txFreq);
+            radioModule.setRxFrequency(Float.parseFloat(makeSafeHamFreq(activeFrequencyStr)));
+            radioModule.setTxTone((byte) Math.max(0, ToneHelper.getToneIndex(memory.txTone)));
+            radioModule.setRxTone((byte) Math.max(0, ToneHelper.getToneIndex(memory.rxTone)));
+        } finally {
+            radioModule.endUpdate();
         }
         txAllowed = isTxAllowed(txFreq);
-
         updateForegroundNotification(memory.name + " (" + memory.frequency + " MHz)");
     }
 
@@ -746,7 +683,7 @@ public class RadioAudioService extends Service {
     }
 
     private void checkScanDueToSquelch() {
-        if (getMode() != RadioMode.SCAN || radioModule == null) {
+        if (getMode() != RadioMode.SCAN) {
             scanSquelchedSinceMs = -1L;
             return;
         }
@@ -858,13 +795,12 @@ public class RadioAudioService extends Service {
 
     private boolean isConnectionReady() {
         return hostToEsp32 != null
-            && radioModule != null
             && serialPort != null
             && usbIoManager != null;
     }
 
     private void closePortAndReset() {
-        radioModule = null;
+        radioModule.detachSender();
         hostToEsp32 = null;
         if (usbIoManager != null) {
             try {
@@ -893,7 +829,7 @@ public class RadioAudioService extends Service {
             return;
         }
         setMode(RadioMode.STARTUP);
-        setRadioType(RadioModuleType.UNKNOWN);
+        clearRadioTypeAndLimits();
         Optional<UsbDevice> device = usbManager.getDeviceList().values().stream()
             .filter(this::isESP32Device)
             .findFirst();
@@ -996,7 +932,7 @@ public class RadioAudioService extends Service {
         usbIoManager.setReadBufferCount(16 * 2);
         usbIoManager.start();
         hostToEsp32 = new Protocol.Sender(usbIoManager);
-        radioModule = new RadioModuleController(hostToEsp32);
+        radioModule.attachSender(hostToEsp32);
         Log.i(TAG, connectLog("setupSerialConnection(): serial transport connected; starting handshake"));
         protocolHandshake.start();
     }
@@ -1054,40 +990,68 @@ public class RadioAudioService extends Service {
         return "thread=" + thread.getName() + "#" + thread.getId();
     }
 
-    /**
-     * @param radioType should be RADIO_TYPE_UHF or RADIO_TYPE_VHF
-     */
-    public void setRadioType(RadioModuleType radioType) {
-        callbacks.setRadioType(radioType);
-        if (!Objects.equals(this.radioType, radioType)) {
-            this.radioType = radioType;
-            updateFrequencyLimitsForBand();
+    public RadioModuleType getRadioType() {
+        Protocol.RfModuleType rfModuleType = radioModule.getRfModuleType();
+        if (Protocol.RfModuleType.RF_SA818_UHF.equals(rfModuleType)) {
+            return RadioModuleType.UHF;
+        }
+        if (Protocol.RfModuleType.RF_SA818_VHF.equals(rfModuleType)) {
+            return RadioModuleType.VHF;
+        }
+        return RadioModuleType.UNKNOWN;
+    }
+
+    private void clearRadioTypeAndLimits() {
+        radioModule.clearFirmwareVersion();
+        callbacks.setRadioType(RadioModuleType.UNKNOWN);
+    }
+
+    public void handleFirmwareVersion(Protocol.FirmwareVersion version) {
+        radioModule.seedFirmwareVersion(version);
+        callbacks.setRadioType(getRadioType());
+        updateTxLimitsForBand();
+    }
+
+    public void updateTxLimitsForBand() {
+        if (RadioModuleType.VHF.equals(getRadioType())) {
+            setMinTxFreq(min2mTxFreq);
+            setMaxTxFreq(max2mTxFreq);
+        } else if (RadioModuleType.UHF.equals(getRadioType())) {
+            setMinTxFreq(min70cmTxFreq);
+            setMaxTxFreq(max70cmTxFreq);
+        }
+        Log.d(TAG, "Radio type set to: " + getRadioType());
+        Log.d(TAG, "Min radio freq: " + getMinRadioFreq());
+        Log.d(TAG, "Max radio freq: " + getMaxRadioFreq());
+        Log.d(TAG, "Min tx freq: " + minTxFreq);
+        Log.d(TAG, "Max tx freq: " + maxTxFreq);
+        float txFrequency = radioModule.getTxFrequency() > 0 ? radioModule.getTxFrequency() : parseActiveFrequencyOrZero();
+        txAllowed = isTxAllowed(txFrequency);
+        Log.d(TAG, String.format("Tx allowed: %b (%s)", txAllowed, txFrequency));
+    }
+
+    private float parseActiveFrequencyOrZero() {
+        try {
+            return Float.parseFloat(activeFrequencyStr);
+        } catch (NumberFormatException e) {
+            return 0.0f;
         }
     }
 
-    public void updateFrequencyLimitsForBand() {
-        // Ensure frequencies we're using match the radioType
-        if (RadioModuleType.VHF.equals(getRadioType())) {
-            setMinRadioFreq(VHF_MIN_FREQ);
-            setMinTxFreq(min2mTxFreq);
-            setMaxTxFreq(max2mTxFreq);
-            setMaxRadioFreq(VHF_MAX_FREQ);
-        } else if (RadioModuleType.UHF.equals(getRadioType())) {
-            setMinRadioFreq(UHF_MIN_FREQ);
-            setMinTxFreq(min70cmTxFreq);
-            setMaxTxFreq(max70cmTxFreq);
-            setMaxRadioFreq(UHF_MAX_FREQ);
-        }
-        Log.d(TAG, "Radio type set to: " + radioType);
-        Log.d(TAG, "Min radio freq: " + minRadioFreq);
-        Log.d(TAG, "Max radio freq: " + maxRadioFreq);
-        Log.d(TAG, "Min tx freq: " + minTxFreq);
-        Log.d(TAG, "Max tx freq: " + maxTxFreq);
-        float txFrequency = radioModule != null && radioModule.getTxFrequency() > 0
-            ? radioModule.getTxFrequency()
-            : Float.parseFloat(activeFrequencyStr);
-        txAllowed = isTxAllowed(txFrequency);
-        Log.d(TAG, String.format("Tx allowed: %b (%s)", txAllowed, txFrequency));
+    public boolean isHasHighLowPowerSwitch() {
+        return radioModule.hasHighLowPowerSwitch();
+    }
+
+    public boolean isHasPhysPttButton() {
+        return radioModule.hasPhysPttButton();
+    }
+
+    public float getMinRadioFreq() {
+        return radioModule.getMinRadioFreq();
+    }
+
+    public float getMaxRadioFreq() {
+        return radioModule.getMaxRadioFreq();
     }
 
     public void setScanning(boolean scanning, boolean goToRxMode) {
@@ -1095,14 +1059,25 @@ public class RadioAudioService extends Service {
             return;
         }
         if (!scanning) {
-            // If squelch was off before we started scanning, turn it off again
-            if (squelch == 0) {
-                tuneToMemory(activeMemoryId, squelch, true);
+            if (scanBaseSquelch >= 0 && scanBaseSquelch != radioModule.getDesiredSquelch()) {
+                radioModule.beginUpdate();
+                try {
+                    radioModule.setSquelch((byte) scanBaseSquelch);
+                    if (activeMemoryId > -1) {
+                        tuneToMemory(activeMemoryId);
+                    } else {
+                        tuneToFreq(activeFrequencyStr);
+                    }
+                } finally {
+                    radioModule.endUpdate();
+                }
             }
+            scanBaseSquelch = -1;
             if (goToRxMode) {
                 setMode(RadioMode.RX);
             }
         } else { // Start scanning
+            scanBaseSquelch = radioModule.getDesiredSquelch();
             setMode(RadioMode.SCAN);
             nextScan();
         }
@@ -1148,10 +1123,17 @@ public class RadioAudioService extends Service {
             } catch (Exception e) {
                 Log.d(TAG, "Memory with id " + candidate.memoryId + " had invalid frequency.");
             }
-            if (!candidate.skipDuringScan && memoryFreqFloat >= minRadioFreq && memoryFreqFloat <= maxRadioFreq) {
+            if (!candidate.skipDuringScan && memoryFreqFloat >= getMinRadioFreq() && memoryFreqFloat <= getMaxRadioFreq()) {
                 scanSquelchedSinceMs = -1L;
                 // If squelch is off (0), use squelch=1 during scanning.
-                tuneToMemory(candidate, squelch > 0 ? squelch : 1, true);
+                int desiredSquelch = scanBaseSquelch >= 0 ? scanBaseSquelch : radioModule.getDesiredSquelch();
+                radioModule.beginUpdate();
+                try {
+                    radioModule.setSquelch((byte) (desiredSquelch > 0 ? desiredSquelch : 1));
+                    tuneToMemory(candidate);
+                } finally {
+                    radioModule.endUpdate();
+                }
                 callbacks.scannedToMemory(candidate.memoryId);
                 return;
             }
@@ -1252,21 +1234,25 @@ public class RadioAudioService extends Service {
         if (param == null || len == null || len < 1) {
             return;
         }
-        handleAx25Packet(java.util.Arrays.copyOf(param, len));
+        handleAx25Packet(len == param.length ? param : java.util.Arrays.copyOf(param, len));
     }
 
     void handleInitialDeviceState(Protocol.DeviceState state) {
-        if (radioModule != null) {
-            radioModule.seedFromDeviceState(state);
+        radioModule.seedFromDeviceState(state);
+        if (state.hasRadioConfig()) {
+            activeFrequencyStr = formatFreq(state.getFreqRx());
+            activeMemoryId = state.getMemoryId();
         }
         handleDeviceState(state);
+        callbacks.initialDeviceStateReceived();
+    }
+
+    void markRadioTransportReady() {
+        radioModule.markTransportReady();
     }
 
     private void handleDeviceState(Protocol.DeviceState state) {
         Log.d(TAG, "Device state: " + state);
-        if (radioModule == null) {
-            return;
-        }
         radioModule.updateDeviceState(state);
         if (radioModule.isAppliedStateInSync() && radioModule.getTxFrequency() > 0) {
             txAllowed = isTxAllowed(radioModule.getTxFrequency());
@@ -1501,23 +1487,11 @@ public class RadioAudioService extends Service {
      * @param highPower true to enable high power mode, false to disable it.
      */
     public void setHighPower(boolean highPower) {
-        if (isHighPower() != highPower) {
-            isHighPower = highPower;
-            applyRadioPreferencesToFirmware(hasHighLowPowerSwitch);
-        }
+        radioModule.setHighPower(highPower);
     }
 
     public boolean isHighPower() {
-        return radioModule != null ? radioModule.isHighPowerEnabled() : isHighPower;
-    }
-
-    void applyRadioPreferencesToFirmware(boolean canSetHighPower) {
-        if (isConnectionReady() && canSetHighPower) {
-            radioModule.setHighPower(isHighPower);
-        }
-        if (isConnectionReady()) {
-            radioModule.setRssi(isRssiOn);
-        }
+        return radioModule.isHighPowerEnabled();
     }
 
     /**
@@ -1531,15 +1505,11 @@ public class RadioAudioService extends Service {
      * @param on true to enable RSSI, false to disable it.
      */
     public void setRssi(boolean on) {
-        if (isRssiOn() != on) {
-            isRssiOn = on;
-            if (isRadioConnected()) {
-                radioModule.setRssi(isRssiOn);
-            }
-        }
+        radioModule.setRssi(on);
     }
 
     public boolean isRssiOn() {
-        return radioModule != null ? radioModule.isRssiEnabled() : isRssiOn;
+        return radioModule.isRssiEnabled();
     }
+
 }

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
@@ -177,6 +177,7 @@ public class RadioAudioService extends Service {
         new OpusUtils.OpusDecoderWrapper(AUDIO_SAMPLE_RATE, OPUS_FRAME_SIZE);
     private final OpusUtils.OpusEncoderWrapper opusEncoder =
         new OpusUtils.OpusEncoderWrapper(AUDIO_SAMPLE_RATE, OPUS_FRAME_SIZE);
+    private final byte[] txAudioFrame = new byte[Protocol.PROTO_MTU];
 
     // === USB / Serial ===
     private UsbManager usbManager;
@@ -1146,9 +1147,8 @@ public class RadioAudioService extends Service {
         if (!dataMode) {
             samples = applyMicGain(samples);
         }
-        byte[] audioFrame = new byte[Protocol.PROTO_MTU];
-        int encodedLength = opusEncoder.encode(samples, audioFrame);
-        hostToEsp32.txAudio(java.util.Arrays.copyOfRange(audioFrame, 0, encodedLength));
+        int encodedLength = opusEncoder.encode(samples, txAudioFrame);
+        hostToEsp32.txAudio(txAudioFrame, encodedLength);
     }
 
     public boolean isRadioConnected() {

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioModuleController.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioModuleController.java
@@ -12,6 +12,7 @@ import static com.vagell.kv4pht.radio.Protocol.DRA818_25K;
  * firmware.
  */
 public class RadioModuleController {
+    private static final int MAX_DESIRED_STATE_RETRIES = 3;
     private static final int DESIRED_DEVICE_FLAGS_MASK =
         Protocol.HOST_STATE_RADIO_CONFIG_VALID
             | Protocol.HOST_STATE_PTT_REQUESTED
@@ -43,6 +44,7 @@ public class RadioModuleController {
     private boolean transportReady = false;
     private byte vfoTxTone = 0;
     private byte vfoRxTone = 0;
+    private int desiredStateRetries = 0;
 
     synchronized void attachSender(Protocol.Sender sender) {
         this.sender = sender;
@@ -61,6 +63,7 @@ public class RadioModuleController {
         lastDeviceState = null;
         firmwareVersion = null;
         appliedStateInSync = false;
+        desiredStateRetries = 0;
     }
 
     synchronized void seedFirmwareVersion(Protocol.FirmwareVersion version) {
@@ -78,6 +81,7 @@ public class RadioModuleController {
         copyDesiredState(deviceState);
         lastDesiredStateSent = desiredState.copy();
         appliedStateInSync = isDeviceStateInSyncWithDesired(state, lastDesiredStateSent);
+        desiredStateRetries = 0;
     }
 
     synchronized void pttDown() {
@@ -219,6 +223,11 @@ public class RadioModuleController {
         lastPhysPttDown = isPhysPttDown();
         lastDeviceState = state;
         appliedStateInSync = isDeviceStateInSyncWithDesired(state, lastDesiredStateSent);
+        if (appliedStateInSync) {
+            desiredStateRetries = 0;
+        } else {
+            retryDesiredStateIfNeeded();
+        }
     }
 
     synchronized boolean isAppliedStateInSync() {
@@ -407,7 +416,20 @@ public class RadioModuleController {
         desiredState.setSequence(desiredState.getSequence() + 1);
         Protocol.HostDesiredState state = desiredState.copy();
         lastDesiredStateSent = state;
+        desiredStateRetries = 0;
         appliedStateInSync = false;
         sender.sendDesiredState(state);
+    }
+
+    private void retryDesiredStateIfNeeded() {
+        if (sender == null
+            || !transportReady
+            || lastDesiredStateSent == null
+            || !desiredState.equals(lastDesiredStateSent)
+            || desiredStateRetries >= MAX_DESIRED_STATE_RETRIES) {
+            return;
+        }
+        desiredStateRetries++;
+        sender.sendDesiredState(lastDesiredStateSent);
     }
 }

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioModuleController.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioModuleController.java
@@ -1,0 +1,288 @@
+package com.vagell.kv4pht.radio;
+
+import static com.vagell.kv4pht.radio.Protocol.DRA818_25K;
+
+/**
+ * Owns the Android-side desired/applied radio state.
+ *
+ * Protocol.Sender only knows how to write frames; this class decides what the
+ * next desired-state snapshot should contain.
+ */
+class RadioModuleController {
+    private static final int DESIRED_DEVICE_FLAGS_MASK =
+        Protocol.HOST_STATE_RADIO_CONFIG_VALID
+            | Protocol.HOST_STATE_PTT_REQUESTED
+            | Protocol.HOST_STATE_RX_AUDIO_OPEN
+            | Protocol.HOST_STATE_HIGH_POWER
+            | Protocol.HOST_STATE_RSSI_ENABLED
+            | Protocol.HOST_STATE_FILTER_PRE
+            | Protocol.HOST_STATE_FILTER_HIGH
+            | Protocol.HOST_STATE_FILTER_LOW;
+
+    private final Protocol.Sender sender;
+    private final Protocol.HostDesiredState desiredState = Protocol.HostDesiredState.builder()
+        .sequence(0)
+        .flags(Protocol.HOST_STATE_HIGH_POWER | Protocol.HOST_STATE_RSSI_ENABLED)
+        .bw(DRA818_25K)
+        .freqTx(0.0f)
+        .freqRx(0.0f)
+        .ctcssTx((byte) 0)
+        .squelch((byte) 0)
+        .ctcssRx((byte) 0)
+        .build();
+    private int updateDepth = 0;
+    private Protocol.HostDesiredState lastDesiredStateSent;
+    private Protocol.DeviceState lastDeviceState;
+    private boolean lastPhysPttDown = false;
+    private boolean appliedStateInSync = false;
+
+    RadioModuleController(Protocol.Sender sender) {
+        this.sender = sender;
+    }
+
+    synchronized void seedFromDeviceState(Protocol.DeviceState state) {
+        lastDeviceState = state;
+        lastPhysPttDown = isPhysPttDown();
+        desiredState.setSequence(state.getAppliedSequence());
+        desiredState.setFlags(state.getFlags() & DESIRED_DEVICE_FLAGS_MASK
+            & ~(Protocol.HOST_STATE_PTT_REQUESTED | Protocol.HOST_STATE_RX_AUDIO_OPEN));
+        desiredState.setBw(state.getBw());
+        desiredState.setFreqTx(state.getFreqTx());
+        desiredState.setFreqRx(state.getFreqRx());
+        desiredState.setCtcssTx(state.getCtcssTx());
+        desiredState.setSquelch(state.getSquelch());
+        desiredState.setCtcssRx(state.getCtcssRx());
+        lastDesiredStateSent = desiredState.copy();
+        appliedStateInSync = isDeviceStateInSyncWithDesired(state, lastDesiredStateSent);
+    }
+
+    synchronized void pttDown() {
+        setDesiredFlags(desiredState.getFlags() | Protocol.HOST_STATE_PTT_REQUESTED);
+    }
+
+    synchronized void pttUp() {
+        setDesiredFlags(desiredState.getFlags() & ~Protocol.HOST_STATE_PTT_REQUESTED);
+    }
+
+    synchronized void beginUpdate() {
+        updateDepth++;
+    }
+
+    synchronized void endUpdate() {
+        if (updateDepth == 0) {
+            return;
+        }
+        updateDepth--;
+        if (updateDepth == 0) {
+            sendDesiredStateIfChanged();
+        }
+    }
+
+    synchronized void setBandwidth(byte bandwidth) {
+        if (desiredState.getBw() == bandwidth) {
+            return;
+        }
+        desiredState.setBw(bandwidth);
+        setRadioConfigValidAndSend();
+    }
+
+    synchronized void setTxFrequency(float txFrequency) {
+        if (Float.compare(desiredState.getFreqTx(), txFrequency) == 0) {
+            return;
+        }
+        desiredState.setFreqTx(txFrequency);
+        setRadioConfigValidAndSend();
+    }
+
+    synchronized void setRxFrequency(float rxFrequency) {
+        if (Float.compare(desiredState.getFreqRx(), rxFrequency) == 0) {
+            return;
+        }
+        desiredState.setFreqRx(rxFrequency);
+        setRadioConfigValidAndSend();
+    }
+
+    synchronized void setTxTone(byte txTone) {
+        if (desiredState.getCtcssTx() == txTone) {
+            return;
+        }
+        desiredState.setCtcssTx(txTone);
+        setRadioConfigValidAndSend();
+    }
+
+    synchronized void setSquelch(byte squelch) {
+        if (desiredState.getSquelch() == squelch) {
+            return;
+        }
+        desiredState.setSquelch(squelch);
+        setRadioConfigValidAndSend();
+    }
+
+    synchronized void setRxTone(byte rxTone) {
+        if (desiredState.getCtcssRx() == rxTone) {
+            return;
+        }
+        desiredState.setCtcssRx(rxTone);
+        setRadioConfigValidAndSend();
+    }
+
+    synchronized void setFilters(boolean emphasis, boolean highpass, boolean lowpass) {
+        int nextFlags = desiredState.getFlags() & ~(Protocol.HOST_STATE_FILTER_PRE | Protocol.HOST_STATE_FILTER_HIGH | Protocol.HOST_STATE_FILTER_LOW);
+        if (emphasis) nextFlags |= Protocol.HOST_STATE_FILTER_PRE;
+        if (highpass) nextFlags |= Protocol.HOST_STATE_FILTER_HIGH;
+        if (lowpass) nextFlags |= Protocol.HOST_STATE_FILTER_LOW;
+        setDesiredFlags(nextFlags);
+    }
+
+    synchronized void stop() {
+        setDesiredFlags(desiredState.getFlags() & ~(Protocol.HOST_STATE_RX_AUDIO_OPEN | Protocol.HOST_STATE_PTT_REQUESTED));
+    }
+
+    synchronized void openAudio() {
+        setDesiredFlags(desiredState.getFlags() | Protocol.HOST_STATE_RX_AUDIO_OPEN);
+    }
+
+    synchronized void closeAudio() {
+        setDesiredFlags(desiredState.getFlags() & ~(Protocol.HOST_STATE_RX_AUDIO_OPEN | Protocol.HOST_STATE_PTT_REQUESTED));
+    }
+
+    synchronized void setHighPower(boolean isHighPower) {
+        int nextFlags;
+        if (isHighPower) {
+            nextFlags = desiredState.getFlags() | Protocol.HOST_STATE_HIGH_POWER;
+        } else {
+            nextFlags = desiredState.getFlags() & ~Protocol.HOST_STATE_HIGH_POWER;
+        }
+        setDesiredFlags(nextFlags);
+    }
+
+    synchronized void setRssi(boolean on) {
+        int nextFlags;
+        if (on) {
+            nextFlags = desiredState.getFlags() | Protocol.HOST_STATE_RSSI_ENABLED;
+        } else {
+            nextFlags = desiredState.getFlags() & ~Protocol.HOST_STATE_RSSI_ENABLED;
+        }
+        setDesiredFlags(nextFlags);
+    }
+
+    synchronized void updateDeviceState(Protocol.DeviceState state) {
+        lastPhysPttDown = isPhysPttDown();
+        lastDeviceState = state;
+        appliedStateInSync = isDeviceStateInSyncWithDesired(state, lastDesiredStateSent);
+    }
+
+    synchronized Protocol.DeviceState getLastDeviceState() {
+        return lastDeviceState;
+    }
+
+    synchronized Protocol.HostDesiredState getLastDesiredStateSent() {
+        return lastDesiredStateSent;
+    }
+
+    synchronized boolean isAppliedStateInSync() {
+        return appliedStateInSync;
+    }
+
+    synchronized boolean hasPendingDesiredState() {
+        return lastDesiredStateSent != null && !appliedStateInSync;
+    }
+
+    synchronized boolean isHighPowerEnabled() {
+        return (desiredState.getFlags() & Protocol.HOST_STATE_HIGH_POWER) != 0;
+    }
+
+    synchronized boolean isRssiEnabled() {
+        return (desiredState.getFlags() & Protocol.HOST_STATE_RSSI_ENABLED) != 0;
+    }
+
+    synchronized byte getBandwidth() {
+        return lastDeviceState != null ? lastDeviceState.getBw() : DRA818_25K;
+    }
+
+    synchronized float getTxFrequency() {
+        return lastDeviceState != null ? lastDeviceState.getFreqTx() : 0.0f;
+    }
+
+    synchronized float getRxFrequency() {
+        return lastDeviceState != null ? lastDeviceState.getFreqRx() : 0.0f;
+    }
+
+    synchronized byte getTxTone() {
+        return lastDeviceState != null ? lastDeviceState.getCtcssTx() : 0;
+    }
+
+    synchronized byte getSquelch() {
+        return lastDeviceState != null ? lastDeviceState.getSquelch() : 0;
+    }
+
+    synchronized byte getRxTone() {
+        return lastDeviceState != null ? lastDeviceState.getCtcssRx() : 0;
+    }
+
+    synchronized int getSMeter9Value() {
+        return Protocol.calculateSMeter9Value(lastDeviceState != null ? lastDeviceState.getLatestRssi() : 0);
+    }
+
+    synchronized boolean isPhysPttDown() {
+        return lastDeviceState != null
+            && (lastDeviceState.getFlags() & Protocol.DEVICE_STATE_PHYS_PTT_DOWN) != 0;
+    }
+
+    synchronized boolean isSquelched() {
+        return lastDeviceState != null
+            && (lastDeviceState.getFlags() & Protocol.DEVICE_STATE_SQUELCHED) != 0;
+    }
+
+    synchronized boolean didPhysPttChange() {
+        return lastPhysPttDown != isPhysPttDown();
+    }
+
+    private boolean isDeviceStateInSyncWithDesired(Protocol.DeviceState deviceState, Protocol.HostDesiredState desiredState) {
+        if (deviceState == null || desiredState == null || deviceState.getLastError() != 0) {
+            return false;
+        }
+        if (deviceState.getAppliedSequence() != desiredState.getSequence()) {
+            return false;
+        }
+        if ((deviceState.getFlags() & DESIRED_DEVICE_FLAGS_MASK) != (desiredState.getFlags() & DESIRED_DEVICE_FLAGS_MASK)) {
+            return false;
+        }
+        if ((desiredState.getFlags() & Protocol.HOST_STATE_RADIO_CONFIG_VALID) == 0) {
+            return true;
+        }
+        return deviceState.getBw() == desiredState.getBw()
+            && Float.compare(deviceState.getFreqTx(), desiredState.getFreqTx()) == 0
+            && Float.compare(deviceState.getFreqRx(), desiredState.getFreqRx()) == 0
+            && deviceState.getCtcssTx() == desiredState.getCtcssTx()
+            && deviceState.getSquelch() == desiredState.getSquelch()
+            && deviceState.getCtcssRx() == desiredState.getCtcssRx();
+    }
+
+    private void setRadioConfigValidAndSend() {
+        desiredState.setFlags(desiredState.getFlags() | Protocol.HOST_STATE_RADIO_CONFIG_VALID);
+        sendDesiredStateIfChanged();
+    }
+
+    private void setDesiredFlags(int nextFlags) {
+        if (desiredState.getFlags() == nextFlags) {
+            return;
+        }
+        desiredState.setFlags(nextFlags);
+        sendDesiredStateIfChanged();
+    }
+
+    private void sendDesiredStateIfChanged() {
+        if (updateDepth == 0 && !desiredState.equals(lastDesiredStateSent)) {
+            sendDesiredState();
+        }
+    }
+
+    private void sendDesiredState() {
+        desiredState.setSequence(desiredState.getSequence() + 1);
+        Protocol.HostDesiredState state = desiredState.copy();
+        lastDesiredStateSent = state;
+        appliedStateInSync = false;
+        sender.sendDesiredState(state);
+    }
+}

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioModuleController.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioModuleController.java
@@ -1,14 +1,17 @@
 package com.vagell.kv4pht.radio;
 
+import static com.vagell.kv4pht.radio.Protocol.DRA818_12K5;
 import static com.vagell.kv4pht.radio.Protocol.DRA818_25K;
 
 /**
  * Owns the Android-side desired/applied radio state.
- *
+ * <p>
  * Protocol.Sender only knows how to write frames; this class decides what the
- * next desired-state snapshot should contain.
+ * next desired-state snapshot should contain. Public getters expose the latest
+ * firmware-reported state; setters mutate desired state that will be sent to
+ * firmware.
  */
-class RadioModuleController {
+public class RadioModuleController {
     private static final int DESIRED_DEVICE_FLAGS_MASK =
         Protocol.HOST_STATE_RADIO_CONFIG_VALID
             | Protocol.HOST_STATE_PTT_REQUESTED
@@ -19,9 +22,11 @@ class RadioModuleController {
             | Protocol.HOST_STATE_FILTER_HIGH
             | Protocol.HOST_STATE_FILTER_LOW;
 
-    private final Protocol.Sender sender;
+    private Protocol.Sender sender;
+    private Protocol.FirmwareVersion firmwareVersion;
     private final Protocol.HostDesiredState desiredState = Protocol.HostDesiredState.builder()
         .sequence(0)
+        .memoryId(-1)
         .flags(Protocol.HOST_STATE_HIGH_POWER | Protocol.HOST_STATE_RSSI_ENABLED)
         .bw(DRA818_25K)
         .freqTx(0.0f)
@@ -35,23 +40,42 @@ class RadioModuleController {
     private Protocol.DeviceState lastDeviceState;
     private boolean lastPhysPttDown = false;
     private boolean appliedStateInSync = false;
+    private boolean transportReady = false;
+    private byte vfoTxTone = 0;
+    private byte vfoRxTone = 0;
 
-    RadioModuleController(Protocol.Sender sender) {
+    synchronized void attachSender(Protocol.Sender sender) {
         this.sender = sender;
+        transportReady = false;
+    }
+
+    synchronized void markTransportReady() {
+        transportReady = true;
+        flushDesiredState();
+    }
+
+    synchronized void detachSender() {
+        sender = null;
+        transportReady = false;
+        lastDesiredStateSent = null;
+        lastDeviceState = null;
+        firmwareVersion = null;
+        appliedStateInSync = false;
+    }
+
+    synchronized void seedFirmwareVersion(Protocol.FirmwareVersion version) {
+        firmwareVersion = version;
+    }
+
+    synchronized void clearFirmwareVersion() {
+        firmwareVersion = null;
     }
 
     synchronized void seedFromDeviceState(Protocol.DeviceState state) {
         lastDeviceState = state;
         lastPhysPttDown = isPhysPttDown();
-        desiredState.setSequence(state.getAppliedSequence());
-        desiredState.setFlags(state.getFlags() & DESIRED_DEVICE_FLAGS_MASK
-            & ~(Protocol.HOST_STATE_PTT_REQUESTED | Protocol.HOST_STATE_RX_AUDIO_OPEN));
-        desiredState.setBw(state.getBw());
-        desiredState.setFreqTx(state.getFreqTx());
-        desiredState.setFreqRx(state.getFreqRx());
-        desiredState.setCtcssTx(state.getCtcssTx());
-        desiredState.setSquelch(state.getSquelch());
-        desiredState.setCtcssRx(state.getCtcssRx());
+        Protocol.HostDesiredState deviceState = desiredFromDeviceState(state);
+        copyDesiredState(deviceState);
         lastDesiredStateSent = desiredState.copy();
         appliedStateInSync = isDeviceStateInSyncWithDesired(state, lastDesiredStateSent);
     }
@@ -64,11 +88,11 @@ class RadioModuleController {
         setDesiredFlags(desiredState.getFlags() & ~Protocol.HOST_STATE_PTT_REQUESTED);
     }
 
-    synchronized void beginUpdate() {
+    public synchronized void beginUpdate() {
         updateDepth++;
     }
 
-    synchronized void endUpdate() {
+    public synchronized void endUpdate() {
         if (updateDepth == 0) {
             return;
         }
@@ -86,6 +110,10 @@ class RadioModuleController {
         setRadioConfigValidAndSend();
     }
 
+    public synchronized void setBandwidth(String bandwidth) {
+        setBandwidth("25kHz".equals(bandwidth) ? DRA818_25K : DRA818_12K5);
+    }
+
     synchronized void setTxFrequency(float txFrequency) {
         if (Float.compare(desiredState.getFreqTx(), txFrequency) == 0) {
             return;
@@ -99,6 +127,14 @@ class RadioModuleController {
             return;
         }
         desiredState.setFreqRx(rxFrequency);
+        setRadioConfigValidAndSend();
+    }
+
+    synchronized void setMemoryId(int memoryId) {
+        if (desiredState.getMemoryId() == memoryId) {
+            return;
+        }
+        desiredState.setMemoryId(memoryId);
         setRadioConfigValidAndSend();
     }
 
@@ -118,6 +154,14 @@ class RadioModuleController {
         setRadioConfigValidAndSend();
     }
 
+    public synchronized void setSquelch(int squelch) {
+        setSquelch((byte) squelch);
+    }
+
+    synchronized void seedDesiredSquelch(int squelch) {
+        desiredState.setSquelch((byte) squelch);
+    }
+
     synchronized void setRxTone(byte rxTone) {
         if (desiredState.getCtcssRx() == rxTone) {
             return;
@@ -126,12 +170,17 @@ class RadioModuleController {
         setRadioConfigValidAndSend();
     }
 
-    synchronized void setFilters(boolean emphasis, boolean highpass, boolean lowpass) {
+    public synchronized void setFilters(boolean emphasis, boolean highpass, boolean lowpass) {
         int nextFlags = desiredState.getFlags() & ~(Protocol.HOST_STATE_FILTER_PRE | Protocol.HOST_STATE_FILTER_HIGH | Protocol.HOST_STATE_FILTER_LOW);
         if (emphasis) nextFlags |= Protocol.HOST_STATE_FILTER_PRE;
         if (highpass) nextFlags |= Protocol.HOST_STATE_FILTER_HIGH;
         if (lowpass) nextFlags |= Protocol.HOST_STATE_FILTER_LOW;
         setDesiredFlags(nextFlags);
+    }
+
+    public synchronized void setVfoTones(byte txTone, byte rxTone) {
+        vfoTxTone = txTone;
+        vfoRxTone = rxTone;
     }
 
     synchronized void stop() {
@@ -146,7 +195,7 @@ class RadioModuleController {
         setDesiredFlags(desiredState.getFlags() & ~(Protocol.HOST_STATE_RX_AUDIO_OPEN | Protocol.HOST_STATE_PTT_REQUESTED));
     }
 
-    synchronized void setHighPower(boolean isHighPower) {
+    public synchronized void setHighPower(boolean isHighPower) {
         int nextFlags;
         if (isHighPower) {
             nextFlags = desiredState.getFlags() | Protocol.HOST_STATE_HIGH_POWER;
@@ -172,23 +221,11 @@ class RadioModuleController {
         appliedStateInSync = isDeviceStateInSyncWithDesired(state, lastDesiredStateSent);
     }
 
-    synchronized Protocol.DeviceState getLastDeviceState() {
-        return lastDeviceState;
-    }
-
-    synchronized Protocol.HostDesiredState getLastDesiredStateSent() {
-        return lastDesiredStateSent;
-    }
-
     synchronized boolean isAppliedStateInSync() {
         return appliedStateInSync;
     }
 
-    synchronized boolean hasPendingDesiredState() {
-        return lastDesiredStateSent != null && !appliedStateInSync;
-    }
-
-    synchronized boolean isHighPowerEnabled() {
+    public synchronized boolean isHighPowerEnabled() {
         return (desiredState.getFlags() & Protocol.HOST_STATE_HIGH_POWER) != 0;
     }
 
@@ -196,28 +233,84 @@ class RadioModuleController {
         return (desiredState.getFlags() & Protocol.HOST_STATE_RSSI_ENABLED) != 0;
     }
 
-    synchronized byte getBandwidth() {
-        return lastDeviceState != null ? lastDeviceState.getBw() : DRA818_25K;
+    public synchronized int getDesiredSquelch() {
+        return desiredState.getSquelch() & 0xFF;
     }
 
-    synchronized float getTxFrequency() {
+    public synchronized String getBandwidthLabel() {
+        return desiredState.getBw() == DRA818_25K ? "25kHz" : "12.5kHz";
+    }
+
+    public synchronized boolean isPreEmphasisEnabled() {
+        return (desiredState.getFlags() & Protocol.HOST_STATE_FILTER_PRE) != 0;
+    }
+
+    public synchronized boolean isHighpassEnabled() {
+        return (desiredState.getFlags() & Protocol.HOST_STATE_FILTER_HIGH) != 0;
+    }
+
+    public synchronized boolean isLowpassEnabled() {
+        return (desiredState.getFlags() & Protocol.HOST_STATE_FILTER_LOW) != 0;
+    }
+
+    public synchronized int getFirmwareVersionNumber() {
+        return firmwareVersion != null ? firmwareVersion.getVer() : -1;
+    }
+
+    public synchronized Protocol.RfModuleType getRfModuleType() {
+        return firmwareVersion != null ? firmwareVersion.getModuleType() : null;
+    }
+
+    public synchronized boolean hasHighLowPowerSwitch() {
+        return firmwareVersion != null && firmwareVersion.isHasHl();
+    }
+
+    public synchronized boolean hasPhysPttButton() {
+        return firmwareVersion != null && firmwareVersion.isHasPhysPtt();
+    }
+
+    public synchronized float getMinRadioFreq() {
+        return firmwareVersion != null ? firmwareVersion.getMinRadioFreq() : 0.0f;
+    }
+
+    public synchronized float getMaxRadioFreq() {
+        return firmwareVersion != null ? firmwareVersion.getMaxRadioFreq() : 999.0f;
+    }
+
+    synchronized float getHalfBandwidthMhz() {
+        return (desiredState.getBw() == DRA818_25K ? 0.025f : 0.0125f) / 2.0f;
+    }
+
+    synchronized byte getVfoTxTone() {
+        return vfoTxTone;
+    }
+
+    synchronized byte getVfoRxTone() {
+        return vfoRxTone;
+    }
+
+    public synchronized boolean hasRadioConfig() {
+        return lastDeviceState != null && lastDeviceState.hasRadioConfig();
+    }
+
+    public synchronized int getMemoryId() {
+        return lastDeviceState != null ? lastDeviceState.getMemoryId() : -1;
+    }
+
+    public synchronized float getTxFrequency() {
         return lastDeviceState != null ? lastDeviceState.getFreqTx() : 0.0f;
     }
 
-    synchronized float getRxFrequency() {
+    public synchronized float getRxFrequency() {
         return lastDeviceState != null ? lastDeviceState.getFreqRx() : 0.0f;
     }
 
-    synchronized byte getTxTone() {
-        return lastDeviceState != null ? lastDeviceState.getCtcssTx() : 0;
+    public synchronized int getTxTone() {
+        return lastDeviceState != null ? lastDeviceState.getCtcssTx() & 0xFF : 0;
     }
 
-    synchronized byte getSquelch() {
-        return lastDeviceState != null ? lastDeviceState.getSquelch() : 0;
-    }
-
-    synchronized byte getRxTone() {
-        return lastDeviceState != null ? lastDeviceState.getCtcssRx() : 0;
+    public synchronized int getRxTone() {
+        return lastDeviceState != null ? lastDeviceState.getCtcssRx() & 0xFF : 0;
     }
 
     synchronized int getSMeter9Value() {
@@ -238,6 +331,37 @@ class RadioModuleController {
         return lastPhysPttDown != isPhysPttDown();
     }
 
+    synchronized void flushDesiredState() {
+        sendDesiredStateIfChanged();
+    }
+
+    private Protocol.HostDesiredState desiredFromDeviceState(Protocol.DeviceState state) {
+        return Protocol.HostDesiredState.builder()
+            .sequence(state.getAppliedSequence())
+            .memoryId(state.getMemoryId())
+            .flags(state.getFlags() & DESIRED_DEVICE_FLAGS_MASK
+                & ~(Protocol.HOST_STATE_PTT_REQUESTED | Protocol.HOST_STATE_RX_AUDIO_OPEN))
+            .bw(state.getBw())
+            .freqTx(state.getFreqTx())
+            .freqRx(state.getFreqRx())
+            .ctcssTx(state.getCtcssTx())
+            .squelch(state.getSquelch())
+            .ctcssRx(state.getCtcssRx())
+            .build();
+    }
+
+    private void copyDesiredState(Protocol.HostDesiredState state) {
+        desiredState.setSequence(state.getSequence());
+        desiredState.setMemoryId(state.getMemoryId());
+        desiredState.setFlags(state.getFlags());
+        desiredState.setBw(state.getBw());
+        desiredState.setFreqTx(state.getFreqTx());
+        desiredState.setFreqRx(state.getFreqRx());
+        desiredState.setCtcssTx(state.getCtcssTx());
+        desiredState.setSquelch(state.getSquelch());
+        desiredState.setCtcssRx(state.getCtcssRx());
+    }
+
     private boolean isDeviceStateInSyncWithDesired(Protocol.DeviceState deviceState, Protocol.HostDesiredState desiredState) {
         if (deviceState == null || desiredState == null || deviceState.getLastError() != 0) {
             return false;
@@ -252,6 +376,7 @@ class RadioModuleController {
             return true;
         }
         return deviceState.getBw() == desiredState.getBw()
+            && deviceState.getMemoryId() == desiredState.getMemoryId()
             && Float.compare(deviceState.getFreqTx(), desiredState.getFreqTx()) == 0
             && Float.compare(deviceState.getFreqRx(), desiredState.getFreqRx()) == 0
             && deviceState.getCtcssTx() == desiredState.getCtcssTx()
@@ -273,7 +398,7 @@ class RadioModuleController {
     }
 
     private void sendDesiredStateIfChanged() {
-        if (updateDepth == 0 && !desiredState.equals(lastDesiredStateSent)) {
+        if (updateDepth == 0 && sender != null && transportReady && !desiredState.equals(lastDesiredStateSent)) {
             sendDesiredState();
         }
     }

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/MainActivity.java
@@ -89,6 +89,7 @@ import com.vagell.kv4pht.data.AppSetting;
 import com.vagell.kv4pht.data.ChannelMemory;
 import com.vagell.kv4pht.databinding.ActivityMainBinding;
 import com.vagell.kv4pht.radio.RadioAudioService;
+import com.vagell.kv4pht.radio.RadioModuleController;
 import com.vagell.kv4pht.radio.RadioMode;
 
 import java.util.ArrayList;
@@ -138,7 +139,6 @@ public class MainActivity extends AppCompatActivity {
 
     // Radio params and related settings
     private String activeFrequencyStr = "0.0000";
-    private int squelch = 0;
     private String callsign = null;
     private boolean stickyPTT = false;
     private boolean disableAnimations = false;
@@ -171,8 +171,8 @@ public class MainActivity extends AppCompatActivity {
     private boolean radioAudioServiceBound = false;
     private final AtomicBoolean bindingInProgress = new AtomicBoolean(false);
 
-    // The firmware version of the kv4p HT radio device that's attached, or -1 if unknown.
-    private int firmwareVersion = -1;
+    private boolean pendingInitialRadioUiSync = false;
+    private boolean initialRadioUiSynced = false;
 
     // This receiver will listen for a broadcast from the RadioAudioService when it's shutting down
     // (this is so that when the user swipes-away the kv4p HT notification, the app closes).
@@ -214,7 +214,7 @@ public class MainActivity extends AppCompatActivity {
                     setScanningUi(false);
                 }
                 if (radioAudioService != null) {
-                    radioAudioService.tuneToMemory(memory, squelch, false);
+                    radioAudioService.tuneToMemory(memory);
                     tuneToMemoryUi(memory.memoryId);
                 }
 
@@ -229,7 +229,7 @@ public class MainActivity extends AppCompatActivity {
                 viewModel.deleteMemoryAsync(memory, () -> viewModel.loadDataAsync(() -> runOnUiThread(() -> {
                     memoriesAdapter.notifyDataSetChanged();
                     if (radioAudioService != null) {
-                        radioAudioService.tuneToFreq(freq, squelch, false); // Stay on the same freq as the now-deleted memory
+                        radioAudioService.tuneToFreq(freq); // Stay on the same freq as the now-deleted memory
                         tuneToFreqUi(freq, false);
                     }
                 })));
@@ -260,6 +260,7 @@ public class MainActivity extends AppCompatActivity {
                 }
                 memoriesAdapter.setMemoriesList(channelMemories);
                 memoriesAdapter.notifyDataSetChanged();
+                trySyncInitialRadioUi();
             }
         });
 
@@ -391,8 +392,8 @@ public class MainActivity extends AppCompatActivity {
                 }
 
                 @Override
-                public void firmwareVersionReceived(int firmwareVer) {
-                    context.firmwareVersion = firmwareVer;
+                public void initialDeviceStateReceived() {
+                    scheduleInitialRadioUiSync();
                 }
 
                 @Override
@@ -577,7 +578,6 @@ public class MainActivity extends AppCompatActivity {
             if (Boolean.TRUE.equals(allGranted)) {
                 final Intent svc = new Intent(this, RadioAudioService.class)
                     .putExtra(AppSetting.SETTING_CALLSIGN, callsign)
-                    .putExtra(AppSetting.SETTING_SQUELCH, squelch)
                     .putExtra("activeMemoryId", activeMemoryId)
                     .putExtra("activeFrequencyStr", activeFrequencyStr);
                 startForegroundService(svc);
@@ -934,25 +934,14 @@ public class MainActivity extends AppCompatActivity {
             final Map<String, String> settings = viewModel.getAppDb().appSettingDao().getAll().stream()
                 .collect(Collectors.toMap(AppSetting::getName, AppSetting::getValue));
             runOnUiThread(() -> {
-                applyRfPowerSetting(settings);
-                applySquelchSettings(settings);
                 applyCallSignSetting(settings);
-                applyGroupAndMemorySettings(settings);
+                applyGroupSetting(settings);
                 applyTxFreqLimitsSettings(settings);
-                applyBandwidthAndGainSettings(settings);
-                applyFiltersSettings(settings);
+                applyMicGainSetting(settings);
                 applyAccessibilitySettings(settings);
                 applyAprsSettings(settings);
             });
         });
-    }
-
-    private void applyRfPowerSetting(Map<String, String> settings) {
-        List<String> powerOptions = Arrays.asList(getResources().getStringArray(R.array.rf_power_options));
-        String power = settings.getOrDefault(AppSetting.SETTING_RF_POWER, powerOptions.get(0));
-        if (radioAudioService != null) {
-            radioAudioService.setHighPower(powerOptions.indexOf(power) == 0);
-        }
     }
 
     private void applyCallSignSetting(Map<String, String> settings) {
@@ -965,24 +954,10 @@ public class MainActivity extends AppCompatActivity {
         }
     }
 
-    private void applyGroupAndMemorySettings(Map<String, String> settings) {
+    private void applyGroupSetting(Map<String, String> settings) {
         String group = settings.get(AppSetting.SETTING_LAST_GROUP);
         if (group != null && !group.isEmpty()) {
             selectMemoryGroup(group);
-        }
-        String lastMemoryIdStr = settings.get(AppSetting.SETTING_LAST_MEMORY_ID);
-        String lastFreq = settings.getOrDefault(AppSetting.SETTING_LAST_FREQ, "0.0000");
-        activeMemoryId = (lastMemoryIdStr != null && !lastMemoryIdStr.equals("-1")) ? Integer.parseInt(lastMemoryIdStr) : -1;
-        activeFrequencyStr = (activeMemoryId == -1) ? lastFreq : null;
-        if (radioAudioService != null) {
-            if (activeMemoryId > -1) {
-                radioAudioService.setActiveMemoryId(activeMemoryId);
-                radioAudioService.tuneToMemory(activeMemoryId, squelch, radioAudioService.getMode() == RadioMode.RX);
-                tuneToMemoryUi(activeMemoryId);
-            } else {
-                radioAudioService.tuneToFreq(activeFrequencyStr, squelch, radioAudioService.getMode() == RadioMode.RX);
-                tuneToFreqUi(activeFrequencyStr, radioAudioService.getMode() == RadioMode.RX);
-            }
         }
     }
 
@@ -996,38 +971,13 @@ public class MainActivity extends AppCompatActivity {
         if (max2m != null) radioAudioService.setMax2mTxFreq(Integer.parseInt(max2m));
         if (min70 != null) radioAudioService.setMin70cmTxFreq(Integer.parseInt(min70));
         if (max70 != null) radioAudioService.setMax70cmTxFreq(Integer.parseInt(max70));
-        radioAudioService.updateFrequencyLimitsForBand();
+        radioAudioService.updateTxLimitsForBand();
     }
 
-    private void applyBandwidthAndGainSettings(Map<String, String> settings) {
+    private void applyMicGainSetting(Map<String, String> settings) {
         if (radioAudioService == null) return;
-        String bandwidth = settings.get(AppSetting.SETTING_BANDWIDTH);
         String gain = settings.get(AppSetting.SETTING_MIC_GAIN_BOOST);
-        if (bandwidth != null) radioAudioService.setBandwidth(bandwidth);
         if (gain != null) radioAudioService.setMicGainBoost(gain);
-    }
-
-    private void applySquelchSettings(Map<String, String> settings) {
-        String squelchStr = settings.get(AppSetting.SETTING_SQUELCH);
-        if (squelchStr == null) return;
-        squelch = Integer.parseInt(squelchStr);
-        if (radioAudioService != null) {
-            radioAudioService.setSquelch(squelch);
-        }
-    }
-
-    private void applyFiltersSettings(Map<String, String> settings) {
-        boolean emphasis = Boolean.parseBoolean(settings.getOrDefault(AppSetting.SETTING_EMPHASIS, "false"));
-        boolean highpass = Boolean.parseBoolean(settings.getOrDefault(AppSetting.SETTING_HIGHPASS, "false"));
-        boolean lowpass = Boolean.parseBoolean(settings.getOrDefault(AppSetting.SETTING_LOWPASS, "false"));
-        if (radioAudioService != null && radioAudioService.isRadioConnected()) {
-            threadPoolExecutor.execute(() -> {
-                if (radioAudioService.getMode() != RadioMode.STARTUP && radioAudioService.getMode() != RadioMode.SCAN) {
-                    radioAudioService.setMode(RadioMode.RX);
-                    radioAudioService.setFilters(emphasis, highpass, lowpass);
-                }
-            });
-        }
     }
 
     private void applyAccessibilitySettings(Map<String, String> settings) {
@@ -1178,7 +1128,7 @@ public class MainActivity extends AppCompatActivity {
             @Override
             public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
                 if (radioAudioService != null) {
-                    radioAudioService.tuneToFreq(activeFrequencyField.getText().toString(), squelch, false);
+                    radioAudioService.tuneToFreq(activeFrequencyField.getText().toString());
                     tuneToFreqUi(radioAudioService.makeSafeHamFreq(activeFrequencyField.getText().toString()), false); // Fixes any invalid freq user may have entered.
                 }
 
@@ -1267,7 +1217,6 @@ public class MainActivity extends AppCompatActivity {
      * interact with the radio (use RadioAudioService for that).
      */
     private void tuneToFreqUi(String frequencyStr, boolean wasForced) {
-        final Context ctx = this;
         activeFrequencyStr = radioAudioService.validateFrequency(frequencyStr);
         activeMemoryId = -1;
 
@@ -1277,36 +1226,6 @@ public class MainActivity extends AppCompatActivity {
         // Unhighlight all memory rows, since this is a simplex frequency.
         viewModel.highlightMemory(null);
         memoriesAdapter.notifyDataSetChanged();
-
-        // Save most recent freq so we can restore it on app restart
-        if (wasForced) { // wasForced means user didn't actually type in the frequency (we shouldn't save it)
-            return;
-        }
-        threadPoolExecutor.execute(new Runnable() {
-            @Override
-            public void run() {
-                synchronized(ctx) { // Avoid 2 threads checking if something is set / setting it at once.
-                    AppSetting lastFreqSetting = viewModel.getAppDb().appSettingDao().getByName(AppSetting.SETTING_LAST_FREQ);
-                    if (lastFreqSetting != null) {
-                        lastFreqSetting.value = frequencyStr;
-                        viewModel.getAppDb().appSettingDao().update(lastFreqSetting);
-                    } else {
-                        lastFreqSetting = new AppSetting(AppSetting.SETTING_LAST_FREQ, frequencyStr);
-                        viewModel.getAppDb().appSettingDao().insertAll(lastFreqSetting);
-                    }
-
-                    // And clear out any saved memory ID, so we restore to a simplex freq on restart.
-                    AppSetting lastMemoryIdSetting = viewModel.getAppDb().appSettingDao().getByName(AppSetting.SETTING_LAST_MEMORY_ID);
-                    if (lastMemoryIdSetting != null) {
-                        lastMemoryIdSetting.value = "-1";
-                        viewModel.getAppDb().appSettingDao().update(lastMemoryIdSetting);
-                    } else {
-                        lastMemoryIdSetting = new AppSetting(AppSetting.SETTING_LAST_MEMORY_ID, "-1");
-                        viewModel.getAppDb().appSettingDao().insertAll(lastMemoryIdSetting);
-                    }
-                }
-            }
-        });
     }
 
     /**
@@ -1325,26 +1244,84 @@ public class MainActivity extends AppCompatActivity {
 
                 showMemoryName(channelMemories.get(i).name);
                 showFrequency(activeFrequencyStr);
-
-                // Save most recent memory so we can restore it on app restart
-                // Could be null if user is just listening to scan in another app, etc.
-                try {
-                    threadPoolExecutor.execute(() -> {
-                        AppSetting lastMemoryIdSetting = viewModel.getAppDb().appSettingDao().getByName(AppSetting.SETTING_LAST_MEMORY_ID);
-                        if (lastMemoryIdSetting != null) {
-                            lastMemoryIdSetting.value = "" + memoryId;
-                            viewModel.getAppDb().appSettingDao().update(lastMemoryIdSetting);
-                        } else {
-                            lastMemoryIdSetting = new AppSetting(AppSetting.SETTING_LAST_MEMORY_ID, "" + memoryId);
-                            viewModel.getAppDb().appSettingDao().insertAll(lastMemoryIdSetting);
-                        }
-                    });
-                } catch (RejectedExecutionException ignored) {
-                    Log.d("DEBUG", "Skipping last-memory persistence because MainActivity is tearing down.");
-                }
                 return;
             }
         }
+    }
+
+    private void scheduleInitialRadioUiSync() {
+        runOnUiThread(() -> {
+            initialRadioUiSynced = false;
+            pendingInitialRadioUiSync = true;
+            trySyncInitialRadioUi();
+        });
+    }
+
+    private void trySyncInitialRadioUi() {
+        if (initialRadioUiSynced || !pendingInitialRadioUiSync || radioAudioService == null) {
+            return;
+        }
+        RadioModuleController radioModule = radioAudioService.getRadioModule();
+        if (!radioModule.hasRadioConfig()) {
+            return;
+        }
+        if (radioModule.getMemoryId() >= 0 && viewModel.getChannelMemories().getValue() == null) {
+            return;
+        }
+
+        ChannelMemory memory = findMatchingMemoryForState();
+        if (memory != null) {
+            tuneToMemoryUi(memory.memoryId);
+            viewModel.highlightMemory(memory);
+            memoriesAdapter.notifyDataSetChanged();
+        } else {
+            tuneToFreqUi(String.format(java.util.Locale.US, "%.4f", radioModule.getRxFrequency()), false);
+        }
+        pendingInitialRadioUiSync = false;
+        initialRadioUiSynced = true;
+    }
+
+    @Nullable
+    private ChannelMemory findMatchingMemoryForState() {
+        RadioModuleController radioModule = radioAudioService.getRadioModule();
+        List<ChannelMemory> channelMemories = viewModel.getChannelMemories().getValue();
+        if (channelMemories == null || radioModule.getMemoryId() < 0 || radioAudioService == null) {
+            return null;
+        }
+        for (ChannelMemory memory : channelMemories) {
+            if (memory.memoryId == radioModule.getMemoryId() && memoryMatchesDeviceState(memory)) {
+                return memory;
+            }
+        }
+        return null;
+    }
+
+    private boolean memoryMatchesDeviceState(ChannelMemory memory) {
+        try {
+            RadioModuleController radioModule = radioAudioService.getRadioModule();
+            float rxFreq = Float.parseFloat(radioAudioService.validateFrequency(memory.frequency));
+            float txFreq = calculateMemoryTxFrequency(memory);
+            return closeEnough(txFreq, radioModule.getTxFrequency())
+                && closeEnough(rxFreq, radioModule.getRxFrequency())
+                && Math.max(0, ToneHelper.getToneIndex(memory.txTone)) == radioModule.getTxTone()
+                && Math.max(0, ToneHelper.getToneIndex(memory.rxTone)) == radioModule.getRxTone();
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    private float calculateMemoryTxFrequency(ChannelMemory memory) {
+        float txFreq = Float.parseFloat(memory.frequency);
+        if (memory.offset == ChannelMemory.OFFSET_UP) {
+            txFreq += memory.offsetKhz / 1000f;
+        } else if (memory.offset == ChannelMemory.OFFSET_DOWN) {
+            txFreq -= memory.offsetKhz / 1000f;
+        }
+        return Float.parseFloat(radioAudioService.validateFrequency(Float.toString(txFreq)));
+    }
+
+    private boolean closeEnough(float left, float right) {
+        return Math.abs(left - right) < 0.0002f;
     }
 
     private void showMemoryName(String name) {
@@ -1713,10 +1690,6 @@ public class MainActivity extends AppCompatActivity {
                 }
             });
 
-            // If squelch was off before we started scanning, turn it off again
-            if (squelch == 0) {
-                tuneToMemoryUi(activeMemoryId);
-            }
         } else { // Start scanning
             runOnUiThread(new Runnable() {
                 @Override
@@ -1819,9 +1792,7 @@ public class MainActivity extends AppCompatActivity {
                                 viewModel.highlightMemory(channelMemories.get(i));
 
                                 if (radioAudioService != null) {
-                                    // Force retune so changed memory fields (e.g. offset/tones) are applied
-                                    // even when memoryId and squelch did not change.
-                                    radioAudioService.tuneToMemory(channelMemories.get(i), squelch, true);
+                                    radioAudioService.tuneToMemory(channelMemories.get(i));
                                 }
 
                                 tuneToMemoryUi(channelMemories.get(i).memoryId);
@@ -1831,6 +1802,9 @@ public class MainActivity extends AppCompatActivity {
                 }
                 break;
             case REQUEST_SETTINGS:
+                if (resultCode == Activity.RESULT_OK && data != null && radioAudioService != null) {
+                    applyRadioSettingsResult(data);
+                }
                 viewModel.loadDataAsync(this::applySettings);
                 break;
             case REQUEST_FIRMWARE:
@@ -1903,9 +1877,30 @@ public class MainActivity extends AppCompatActivity {
         intent.putExtra("requestCode", REQUEST_SETTINGS);
         if (radioAudioService != null && radioAudioService.isRadioConnected()) {
             intent.putExtra("hasHighLowPowerSwitch", radioAudioService.isHasHighLowPowerSwitch());
-            intent.putExtra("firmwareVersion", firmwareVersion);
+            intent.putExtra("firmwareVersion", radioAudioService.getRadioModule().getFirmwareVersionNumber());
+            intent.putExtra(SettingsActivity.EXTRA_RF_POWER_HIGH, radioAudioService.getRadioModule().isHighPowerEnabled());
+            intent.putExtra(SettingsActivity.EXTRA_BANDWIDTH, radioAudioService.getRadioModule().getBandwidthLabel());
+            intent.putExtra(SettingsActivity.EXTRA_SQUELCH, radioAudioService.getRadioModule().getDesiredSquelch());
+            intent.putExtra(SettingsActivity.EXTRA_FILTER_PRE, radioAudioService.getRadioModule().isPreEmphasisEnabled());
+            intent.putExtra(SettingsActivity.EXTRA_FILTER_HIGH, radioAudioService.getRadioModule().isHighpassEnabled());
+            intent.putExtra(SettingsActivity.EXTRA_FILTER_LOW, radioAudioService.getRadioModule().isLowpassEnabled());
         }
         startActivityForResult(intent, REQUEST_SETTINGS);
+    }
+
+    private void applyRadioSettingsResult(Intent data) {
+        radioAudioService.getRadioModule().beginUpdate();
+        try {
+            radioAudioService.getRadioModule().setHighPower(data.getBooleanExtra(SettingsActivity.EXTRA_RF_POWER_HIGH, true));
+            radioAudioService.getRadioModule().setBandwidth(data.getStringExtra(SettingsActivity.EXTRA_BANDWIDTH));
+            radioAudioService.getRadioModule().setSquelch(data.getIntExtra(SettingsActivity.EXTRA_SQUELCH, radioAudioService.getRadioModule().getDesiredSquelch()));
+            radioAudioService.getRadioModule().setFilters(
+                data.getBooleanExtra(SettingsActivity.EXTRA_FILTER_PRE, false),
+                data.getBooleanExtra(SettingsActivity.EXTRA_FILTER_HIGH, false),
+                data.getBooleanExtra(SettingsActivity.EXTRA_FILTER_LOW, false));
+        } finally {
+            radioAudioService.getRadioModule().endUpdate();
+        }
     }
 
     public void moreClicked(View view) {

--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/SettingsActivity.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/ui/SettingsActivity.java
@@ -46,7 +46,6 @@ import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
-import java.util.function.IntConsumer;
 import java.util.stream.Collectors;
 
 public class SettingsActivity extends AppCompatActivity {
@@ -54,6 +53,12 @@ public class SettingsActivity extends AppCompatActivity {
     private MainViewModel viewModel = null;
     private boolean hasHighLowPowerSwitch = false;
     private int firmwareVersion = -1;
+    public static final String EXTRA_RF_POWER_HIGH = "rfPowerHigh";
+    public static final String EXTRA_BANDWIDTH = "bandwidth";
+    public static final String EXTRA_SQUELCH = "squelch";
+    public static final String EXTRA_FILTER_PRE = "filterPre";
+    public static final String EXTRA_FILTER_HIGH = "filterHigh";
+    public static final String EXTRA_FILTER_LOW = "filterLow";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -145,13 +150,6 @@ public class SettingsActivity extends AppCompatActivity {
         }
     }
 
-    private void setSliderIfPresent(Map<String, String> settings, String key, int viewId) {
-        if (settings.containsKey(key)) {
-            this.<Slider>findViewById(viewId)
-                .setValue(Float.parseFloat(Optional.ofNullable(settings.get(key)).orElse("0")));
-        }
-    }
-
     private void setDropdownIfPresent(Map<String, String> settings, String key, int viewId) {
         setDropdownIfPresent(settings, key, viewId, "");
     }
@@ -163,11 +161,6 @@ public class SettingsActivity extends AppCompatActivity {
         }
     }
 
-    private void setDropdownWithDefault(Map<String, String> settings, String key, int viewId, String defaultValue) {
-        this.<AutoCompleteTextView>findViewById(viewId)
-            .setText(settings.getOrDefault(key, defaultValue), false);
-    }
-
     private void populateOriginalValues(Runnable callback) {
         threadPoolExecutor.execute(() -> {
             final Map<String, String> settings = viewModel.getAppDb().appSettingDao().getAll().stream()
@@ -175,27 +168,34 @@ public class SettingsActivity extends AppCompatActivity {
             runOnUiThread(() -> {
                 String mhz = getString(R.string.mhz);
                 setTextIfPresent(settings, AppSetting.SETTING_CALLSIGN, R.id.callsignTextInputEditText);
-                setSliderIfPresent(settings, AppSetting.SETTING_SQUELCH, R.id.squelchSlider);
-                setSwitchIfPresent(settings, AppSetting.SETTING_EMPHASIS, R.id.emphasisSwitch);
-                setSwitchIfPresent(settings, AppSetting.SETTING_HIGHPASS, R.id.highpassSwitch);
-                setSwitchIfPresent(settings, AppSetting.SETTING_LOWPASS, R.id.lowpassSwitch);
                 setSwitchIfPresent(settings, AppSetting.SETTING_STICKY_PTT, R.id.stickyPTTSwitch);
                 setSwitchIfPresent(settings, AppSetting.SETTING_DISABLE_ANIMATIONS, R.id.noAnimationsSwitch);
                 setSwitchIfPresent(settings, AppSetting.SETTING_APRS_BEACON_POSITION, R.id.aprsPositionSwitch);
                 setDropdownIfPresent(settings, AppSetting.SETTING_APRS_POSITION_ACCURACY, R.id.aprsPositionAccuracyTextView);
-                setDropdownIfPresent(settings, AppSetting.SETTING_BANDWIDTH, R.id.bandwidthTextView);
+                setRadioSettingsFromIntent();
                 setDropdownIfPresent(settings, AppSetting.SETTING_MIN_2_M_TX_FREQ, R.id.min2mFreqTextView, mhz);
                 setDropdownIfPresent(settings, AppSetting.SETTING_MAX_2_M_TX_FREQ, R.id.max2mFreqTextView, mhz);
                 setDropdownIfPresent(settings, AppSetting.SETTING_MIN_70_CM_TX_FREQ, R.id.min70cmFreqTextView, mhz);
                 setDropdownIfPresent(settings, AppSetting.SETTING_MAX_70_CM_TX_FREQ, R.id.max70cmFreqTextView, mhz);
                 setDropdownIfPresent(settings, AppSetting.SETTING_MIC_GAIN_BOOST, R.id.micGainBoostTextView);
-                if (hasHighLowPowerSwitch) {
-                    setDropdownWithDefault(settings, AppSetting.SETTING_RF_POWER, R.id.rfPowerTextView,
-                        getResources().getStringArray(R.array.rf_power_options)[0]);
-                }
                 callback.run();
             });
         });
+    }
+
+    private void setRadioSettingsFromIntent() {
+        this.<Slider>findViewById(R.id.squelchSlider).setValue(getIntent().getIntExtra(EXTRA_SQUELCH, 0));
+        this.<Switch>findViewById(R.id.emphasisSwitch).setChecked(getIntent().getBooleanExtra(EXTRA_FILTER_PRE, false));
+        this.<Switch>findViewById(R.id.highpassSwitch).setChecked(getIntent().getBooleanExtra(EXTRA_FILTER_HIGH, false));
+        this.<Switch>findViewById(R.id.lowpassSwitch).setChecked(getIntent().getBooleanExtra(EXTRA_FILTER_LOW, false));
+        this.<AutoCompleteTextView>findViewById(R.id.bandwidthTextView)
+            .setText(getIntent().getStringExtra(EXTRA_BANDWIDTH) != null ? getIntent().getStringExtra(EXTRA_BANDWIDTH) : getString(R.string.wide), false);
+
+        String[] powerOptions = getResources().getStringArray(R.array.rf_power_options);
+        if (powerOptions.length > 0) {
+            this.<AutoCompleteTextView>findViewById(R.id.rfPowerTextView)
+                .setText(powerOptions[getIntent().getBooleanExtra(EXTRA_RF_POWER_HIGH, true) ? 0 : Math.min(1, powerOptions.length - 1)], false);
+        }
     }
 
     public void closedCaptionsButtonClicked(View view) {
@@ -217,8 +217,21 @@ public class SettingsActivity extends AppCompatActivity {
     }
 
     public void doneButtonClicked(View view) {
-        setResult(Activity.RESULT_OK);
+        Intent data = new Intent()
+            .putExtra(EXTRA_RF_POWER_HIGH, isHighPowerSelected())
+            .putExtra(EXTRA_BANDWIDTH, this.<AutoCompleteTextView>findViewById(R.id.bandwidthTextView).getText().toString().trim())
+            .putExtra(EXTRA_SQUELCH, (int) this.<Slider>findViewById(R.id.squelchSlider).getValue())
+            .putExtra(EXTRA_FILTER_PRE, this.<Switch>findViewById(R.id.emphasisSwitch).isChecked())
+            .putExtra(EXTRA_FILTER_HIGH, this.<Switch>findViewById(R.id.highpassSwitch).isChecked())
+            .putExtra(EXTRA_FILTER_LOW, this.<Switch>findViewById(R.id.lowpassSwitch).isChecked());
+        setResult(Activity.RESULT_OK, data);
         finish();
+    }
+
+    private boolean isHighPowerSelected() {
+        String[] powerOptions = getResources().getStringArray(R.array.rf_power_options);
+        String selected = this.<AutoCompleteTextView>findViewById(R.id.rfPowerTextView).getText().toString().trim();
+        return powerOptions.length == 0 || selected.equals(powerOptions[0]);
     }
 
     private void attachTextView(int viewId, Consumer<String> onTextChanged) {
@@ -244,25 +257,14 @@ public class SettingsActivity extends AppCompatActivity {
         ((Switch) findViewById(id)).setOnCheckedChangeListener((buttonView, isChecked) -> onChange.accept(isChecked));
     }
 
-    private void attachSlider(int viewId, IntConsumer onValueChanged) {
-        Slider slider = findViewById(viewId);
-        slider.addOnChangeListener((s, value, fromUser) -> onValueChanged.accept((int) value));
-    }
-
     private void attachListeners() {
         attachTextView(R.id.callsignTextInputEditText, text -> setCallsign(text.toUpperCase()));
         attachTextView(R.id.aprsPositionAccuracyTextView, this::setAprsPositionAccuracy);
-        attachTextView(R.id.bandwidthTextView, this::setBandwidth);
         attachTextView(R.id.min2mFreqTextView, text -> setMin2mTxFreq(extractPrefix(text)));
         attachTextView(R.id.max2mFreqTextView, text -> setMax2mTxFreq(extractPrefix(text)));
         attachTextView(R.id.min70cmFreqTextView, text -> setMin70cmTxFreq(extractPrefix(text)));
         attachTextView(R.id.max70cmFreqTextView, text -> setMax70cmTxFreq(extractPrefix(text)));
         attachTextView(R.id.micGainBoostTextView, this::setMicGainBoost);
-        attachTextView(R.id.rfPowerTextView, this::setRfPower);
-        attachSlider(R.id.squelchSlider, this::setSquelch);
-        attachSwitch(R.id.emphasisSwitch, this::setEmphasisFilter);
-        attachSwitch(R.id.highpassSwitch, this::setHighpassFilter);
-        attachSwitch(R.id.lowpassSwitch, this::setLowpassFilter);
         attachSwitch(R.id.stickyPTTSwitch, this::setStickyPTT);
         attachSwitch(R.id.noAnimationsSwitch, this::setNoAnimations);
         attachSwitch(R.id.aprsPositionSwitch, this::setAprsBeaconPosition);
@@ -278,10 +280,6 @@ public class SettingsActivity extends AppCompatActivity {
 
     private void setAprsPositionAccuracy(String accuracy) {
         saveAppSettingAsync(AppSetting.SETTING_APRS_POSITION_ACCURACY, accuracy);
-    }
-
-    private void setBandwidth(String bandwidth) {
-        saveAppSettingAsync(AppSetting.SETTING_BANDWIDTH, bandwidth);
     }
 
     private void setMin2mTxFreq(String freq) {
@@ -304,28 +302,8 @@ public class SettingsActivity extends AppCompatActivity {
         saveAppSettingAsync(AppSetting.SETTING_MIC_GAIN_BOOST, level);
     }
 
-    private void setRfPower(String rfPower) {
-        saveAppSettingAsync(AppSetting.SETTING_RF_POWER, rfPower);
-    }
-
     private void setCallsign(String callsign) {
         saveAppSettingAsync(AppSetting.SETTING_CALLSIGN, callsign);
-    }
-
-    private void setSquelch(int squelch) {
-        saveAppSettingAsync(AppSetting.SETTING_SQUELCH, Integer.toString(squelch));
-    }
-
-    private void setEmphasisFilter(boolean enabled) {
-        saveAppSettingAsync(AppSetting.SETTING_EMPHASIS, Boolean.toString(enabled));
-    }
-
-    private void setHighpassFilter(boolean enabled) {
-        saveAppSettingAsync(AppSetting.SETTING_HIGHPASS, Boolean.toString(enabled));
-    }
-
-    private void setLowpassFilter(boolean enabled) {
-        saveAppSettingAsync(AppSetting.SETTING_LOWPASS, Boolean.toString(enabled));
     }
 
     private void setStickyPTT(boolean enabled) {

--- a/android-src/KV4PHT/app/src/test/java/com/vagell/kv4pht/radio/ProtocolKissTest.java
+++ b/android-src/KV4PHT/app/src/test/java/com/vagell/kv4pht/radio/ProtocolKissTest.java
@@ -3,6 +3,7 @@ package com.vagell.kv4pht.radio;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Before;
@@ -13,6 +14,9 @@ public class ProtocolKissTest {
     private Protocol.RcvCommand command;
     private byte[] payload;
     private int payloadLen;
+    private boolean ax25Called;
+    private byte[] ax25Payload;
+    private int ax25PayloadLen;
 
     @Before
     public void setUp() {
@@ -20,6 +24,9 @@ public class ProtocolKissTest {
         command = Protocol.RcvCommand.COMMAND_RCV_UNKNOWN;
         payload = new byte[0];
         payloadLen = 0;
+        ax25Called = false;
+        ax25Payload = new byte[0];
+        ax25PayloadLen = 0;
     }
 
     @Test
@@ -72,10 +79,10 @@ public class ProtocolKissTest {
             (byte) Protocol.KISS_FEND,
         });
 
-        assertTrue(called);
-        assertEquals(Protocol.RcvCommand.COMMAND_RX_AX25_PACKET, command);
-        assertEquals(4, payloadLen);
-        assertArrayEquals(new byte[]{0x11, (byte) Protocol.KISS_FEND, 0x22, (byte) Protocol.KISS_FESC}, payload);
+        assertFalse(called);
+        assertTrue(ax25Called);
+        assertEquals(4, ax25PayloadLen);
+        assertArrayEquals(new byte[]{0x11, (byte) Protocol.KISS_FEND, 0x22, (byte) Protocol.KISS_FESC}, ax25Payload);
     }
 
     @Test
@@ -150,12 +157,12 @@ public class ProtocolKissTest {
         byte[] commandPayload = new byte[]{0x01, 0x02, 0x03};
         byte[] frame = Protocol.buildKissFrame(
             Protocol.KISS_CMD_SETHARDWARE,
-            Protocol.buildKv4pVendorPayload(Protocol.RcvCommand.COMMAND_SMETER_REPORT.getValue(), commandPayload));
+            Protocol.buildKv4pVendorPayload(Protocol.RcvCommand.COMMAND_DEVICE_STATE.getValue(), commandPayload));
 
         newParser().processBytes(frame);
 
         assertTrue(called);
-        assertEquals(Protocol.RcvCommand.COMMAND_SMETER_REPORT, command);
+        assertEquals(Protocol.RcvCommand.COMMAND_DEVICE_STATE, command);
         assertEquals(commandPayload.length, payloadLen);
         assertArrayEquals(commandPayload, payload);
     }
@@ -193,6 +200,126 @@ public class ProtocolKissTest {
         assertEquals(Protocol.RfModuleType.RF_SA818_UHF, parsed.get().getModuleType());
         assertTrue(parsed.get().isHasHl());
         assertTrue(parsed.get().isHasPhysPtt());
+        assertNull(parsed.get().getDeviceState());
+    }
+
+    @Test
+    public void helloCarriesFirmwareVersionAndInitialDeviceStatePayload() {
+        java.nio.ByteBuffer helloPayload = java.nio.ByteBuffer.allocate(34).order(java.nio.ByteOrder.LITTLE_ENDIAN);
+        helloPayload.putShort((short) 16);
+        helloPayload.put((byte) 'f');
+        helloPayload.putInt(2048);
+        helloPayload.putInt(1);
+        helloPayload.put((byte) 0x07);
+        helloPayload.putInt(9);
+        helloPayload.putShort((short) Protocol.HOST_STATE_RADIO_CONFIG_VALID);
+        helloPayload.put(Protocol.DRA818_12K5);
+        helloPayload.putFloat(144.3900f);
+        helloPayload.putFloat(144.3900f);
+        helloPayload.put((byte) 4);
+        helloPayload.put((byte) 5);
+        helloPayload.put((byte) 6);
+        helloPayload.put((byte) 'f');
+        helloPayload.put((byte) Protocol.DeviceMode.DEVICE_MODE_STOPPED.getValue());
+        helloPayload.put((byte) 0);
+        helloPayload.put((byte) 123);
+        byte[] frame = Protocol.buildKissFrame(
+            Protocol.KISS_CMD_SETHARDWARE,
+            Protocol.buildKv4pVendorPayload(Protocol.RcvCommand.COMMAND_HELLO.getValue(), helloPayload.array()));
+
+        newParser().processBytes(frame);
+
+        assertTrue(called);
+        assertEquals(Protocol.RcvCommand.COMMAND_HELLO, command);
+        assertEquals(helloPayload.array().length, payloadLen);
+        java.util.Optional<Protocol.FirmwareVersion> parsed = Protocol.FirmwareVersion.from(payload, payloadLen);
+        assertTrue(parsed.isPresent());
+        assertEquals(16, parsed.get().getVer());
+        assertTrue(parsed.get().getDeviceState() != null);
+        assertEquals(9, parsed.get().getDeviceState().getAppliedSequence());
+        assertEquals(123, parsed.get().getDeviceState().getLatestRssi());
+    }
+
+    @Test
+    public void hostDesiredStateSerializesAsPackedFirmwareStruct() {
+        byte[] payload = Protocol.HostDesiredState.builder()
+            .sequence(7)
+            .flags(Protocol.HOST_STATE_RADIO_CONFIG_VALID | Protocol.HOST_STATE_RX_AUDIO_OPEN)
+            .bw(Protocol.DRA818_25K)
+            .freqTx(146.5200f)
+            .freqRx(146.5200f)
+            .ctcssTx((byte) 1)
+            .squelch((byte) 2)
+            .ctcssRx((byte) 3)
+            .build()
+            .toBytes();
+
+        assertEquals(18, payload.length);
+        assertEquals(7, java.nio.ByteBuffer.wrap(payload).order(java.nio.ByteOrder.LITTLE_ENDIAN).getInt());
+    }
+
+    @Test
+    public void radioModuleControllerSeedsInitialDeviceStateBeforeFirstSend() {
+        CapturingSender sender = new CapturingSender();
+        RadioModuleController controller = new RadioModuleController(sender);
+        Protocol.DeviceState initialState = Protocol.DeviceState.builder()
+            .appliedSequence(7)
+            .flags(Protocol.HOST_STATE_RADIO_CONFIG_VALID
+                | Protocol.HOST_STATE_HIGH_POWER
+                | Protocol.HOST_STATE_RSSI_ENABLED)
+            .bw(Protocol.DRA818_12K5)
+            .freqTx(144.3900f)
+            .freqRx(144.3900f)
+            .ctcssTx((byte) 4)
+            .squelch((byte) 5)
+            .ctcssRx((byte) 6)
+            .radioModuleStatus(Protocol.RadioStatus.RADIO_STATUS_FOUND)
+            .mode(Protocol.DeviceMode.DEVICE_MODE_STOPPED)
+            .lastError(0)
+            .latestRssi(123)
+            .build();
+
+        controller.seedFromDeviceState(initialState);
+        controller.openAudio();
+
+        assertEquals(1, sender.sentStates.size());
+        Protocol.HostDesiredState sent = sender.sentStates.get(0);
+        assertEquals(8, sent.getSequence());
+        assertTrue((sent.getFlags() & Protocol.HOST_STATE_RADIO_CONFIG_VALID) != 0);
+        assertTrue((sent.getFlags() & Protocol.HOST_STATE_RX_AUDIO_OPEN) != 0);
+        assertTrue((sent.getFlags() & Protocol.HOST_STATE_HIGH_POWER) != 0);
+        assertTrue((sent.getFlags() & Protocol.HOST_STATE_RSSI_ENABLED) != 0);
+        assertEquals(Protocol.DRA818_12K5, sent.getBw());
+        assertEquals(144.3900f, sent.getFreqTx(), 0.0001f);
+        assertEquals(144.3900f, sent.getFreqRx(), 0.0001f);
+        assertEquals(4, sent.getCtcssTx());
+        assertEquals(5, sent.getSquelch());
+        assertEquals(6, sent.getCtcssRx());
+    }
+
+    @Test
+    public void deviceStateParsesPackedFirmwareStruct() {
+        java.nio.ByteBuffer payload = java.nio.ByteBuffer.allocate(22).order(java.nio.ByteOrder.LITTLE_ENDIAN);
+        payload.putInt(9);
+        payload.putShort((short) (Protocol.HOST_STATE_RADIO_CONFIG_VALID | Protocol.DEVICE_STATE_TX_ACTIVE));
+        payload.put(Protocol.DRA818_12K5);
+        payload.putFloat(144.3900f);
+        payload.putFloat(144.3900f);
+        payload.put((byte) 4);
+        payload.put((byte) 5);
+        payload.put((byte) 6);
+        payload.put((byte) 'f');
+        payload.put((byte) Protocol.DeviceMode.DEVICE_MODE_TX.getValue());
+        payload.put((byte) 0);
+        payload.put((byte) 123);
+
+        java.util.Optional<Protocol.DeviceState> parsed = Protocol.DeviceState.from(payload.array(), payload.array().length);
+
+        assertTrue(parsed.isPresent());
+        assertEquals(9, parsed.get().getAppliedSequence());
+        assertEquals(Protocol.DeviceMode.DEVICE_MODE_TX, parsed.get().getMode());
+        assertEquals(Protocol.RadioStatus.RADIO_STATUS_FOUND, parsed.get().getRadioModuleStatus());
+        assertEquals(123, parsed.get().getLatestRssi());
     }
 
     @Test
@@ -213,6 +340,23 @@ public class ProtocolKissTest {
             command = cmd;
             payloadLen = len;
             payload = java.util.Arrays.copyOf(param, len);
+        }, (param, len) -> {
+            ax25Called = true;
+            ax25PayloadLen = len;
+            ax25Payload = java.util.Arrays.copyOf(param, len);
         });
+    }
+
+    private static class CapturingSender extends Protocol.Sender {
+        private final java.util.List<Protocol.HostDesiredState> sentStates = new java.util.ArrayList<>();
+
+        CapturingSender() {
+            super(null);
+        }
+
+        @Override
+        public void sendDesiredState(Protocol.HostDesiredState state) {
+            sentStates.add(state.copy());
+        }
     }
 }

--- a/android-src/KV4PHT/app/src/test/java/com/vagell/kv4pht/radio/ProtocolKissTest.java
+++ b/android-src/KV4PHT/app/src/test/java/com/vagell/kv4pht/radio/ProtocolKissTest.java
@@ -184,20 +184,23 @@ public class ProtocolKissTest {
 
     @Test
     public void firmwareVersionParsesSingleFeaturesByte() {
-        byte[] payload = new byte[]{
-            0x10, 0x00,                  // firmware version 16
-            'f',                         // radio module found
-            0x00, 0x08, 0x00, 0x00,      // window size 2048
-            0x01, 0x00, 0x00, 0x00,      // UHF module
-            0x03,                        // has HL + physical PTT
-        };
+        java.nio.ByteBuffer payload = java.nio.ByteBuffer.allocate(20).order(java.nio.ByteOrder.LITTLE_ENDIAN);
+        payload.putShort((short) 16);
+        payload.put((byte) 'f');
+        payload.putInt(2048);
+        payload.putInt(1);
+        payload.putFloat(400.0f);
+        payload.putFloat(480.0f);
+        payload.put((byte) 0x03);
 
-        java.util.Optional<Protocol.FirmwareVersion> parsed = Protocol.FirmwareVersion.from(payload, payload.length);
+        java.util.Optional<Protocol.FirmwareVersion> parsed = Protocol.FirmwareVersion.from(payload.array(), payload.array().length);
 
         assertTrue(parsed.isPresent());
         assertEquals(16, parsed.get().getVer());
         assertEquals(2048, parsed.get().getWindowSize());
         assertEquals(Protocol.RfModuleType.RF_SA818_UHF, parsed.get().getModuleType());
+        assertEquals(400.0f, parsed.get().getMinRadioFreq(), 0.0001f);
+        assertEquals(480.0f, parsed.get().getMaxRadioFreq(), 0.0001f);
         assertTrue(parsed.get().isHasHl());
         assertTrue(parsed.get().isHasPhysPtt());
         assertNull(parsed.get().getDeviceState());
@@ -205,13 +208,16 @@ public class ProtocolKissTest {
 
     @Test
     public void helloCarriesFirmwareVersionAndInitialDeviceStatePayload() {
-        java.nio.ByteBuffer helloPayload = java.nio.ByteBuffer.allocate(34).order(java.nio.ByteOrder.LITTLE_ENDIAN);
+        java.nio.ByteBuffer helloPayload = java.nio.ByteBuffer.allocate(46).order(java.nio.ByteOrder.LITTLE_ENDIAN);
         helloPayload.putShort((short) 16);
         helloPayload.put((byte) 'f');
         helloPayload.putInt(2048);
         helloPayload.putInt(1);
+        helloPayload.putFloat(400.0f);
+        helloPayload.putFloat(480.0f);
         helloPayload.put((byte) 0x07);
         helloPayload.putInt(9);
+        helloPayload.putInt(42);
         helloPayload.putShort((short) Protocol.HOST_STATE_RADIO_CONFIG_VALID);
         helloPayload.put(Protocol.DRA818_12K5);
         helloPayload.putFloat(144.3900f);
@@ -235,8 +241,11 @@ public class ProtocolKissTest {
         java.util.Optional<Protocol.FirmwareVersion> parsed = Protocol.FirmwareVersion.from(payload, payloadLen);
         assertTrue(parsed.isPresent());
         assertEquals(16, parsed.get().getVer());
+        assertEquals(400.0f, parsed.get().getMinRadioFreq(), 0.0001f);
+        assertEquals(480.0f, parsed.get().getMaxRadioFreq(), 0.0001f);
         assertTrue(parsed.get().getDeviceState() != null);
         assertEquals(9, parsed.get().getDeviceState().getAppliedSequence());
+        assertEquals(42, parsed.get().getDeviceState().getMemoryId());
         assertEquals(123, parsed.get().getDeviceState().getLatestRssi());
     }
 
@@ -244,6 +253,7 @@ public class ProtocolKissTest {
     public void hostDesiredStateSerializesAsPackedFirmwareStruct() {
         byte[] payload = Protocol.HostDesiredState.builder()
             .sequence(7)
+            .memoryId(42)
             .flags(Protocol.HOST_STATE_RADIO_CONFIG_VALID | Protocol.HOST_STATE_RX_AUDIO_OPEN)
             .bw(Protocol.DRA818_25K)
             .freqTx(146.5200f)
@@ -254,16 +264,20 @@ public class ProtocolKissTest {
             .build()
             .toBytes();
 
-        assertEquals(18, payload.length);
-        assertEquals(7, java.nio.ByteBuffer.wrap(payload).order(java.nio.ByteOrder.LITTLE_ENDIAN).getInt());
+        java.nio.ByteBuffer parsed = java.nio.ByteBuffer.wrap(payload).order(java.nio.ByteOrder.LITTLE_ENDIAN);
+        assertEquals(22, payload.length);
+        assertEquals(7, parsed.getInt());
+        assertEquals(42, parsed.getInt());
     }
 
     @Test
     public void radioModuleControllerSeedsInitialDeviceStateBeforeFirstSend() {
         CapturingSender sender = new CapturingSender();
-        RadioModuleController controller = new RadioModuleController(sender);
+        RadioModuleController controller = new RadioModuleController();
+        controller.attachSender(sender);
         Protocol.DeviceState initialState = Protocol.DeviceState.builder()
             .appliedSequence(7)
+            .memoryId(42)
             .flags(Protocol.HOST_STATE_RADIO_CONFIG_VALID
                 | Protocol.HOST_STATE_HIGH_POWER
                 | Protocol.HOST_STATE_RSSI_ENABLED)
@@ -280,6 +294,7 @@ public class ProtocolKissTest {
             .build();
 
         controller.seedFromDeviceState(initialState);
+        controller.markTransportReady();
         controller.openAudio();
 
         assertEquals(1, sender.sentStates.size());
@@ -290,6 +305,7 @@ public class ProtocolKissTest {
         assertTrue((sent.getFlags() & Protocol.HOST_STATE_HIGH_POWER) != 0);
         assertTrue((sent.getFlags() & Protocol.HOST_STATE_RSSI_ENABLED) != 0);
         assertEquals(Protocol.DRA818_12K5, sent.getBw());
+        assertEquals(42, sent.getMemoryId());
         assertEquals(144.3900f, sent.getFreqTx(), 0.0001f);
         assertEquals(144.3900f, sent.getFreqRx(), 0.0001f);
         assertEquals(4, sent.getCtcssTx());
@@ -299,8 +315,9 @@ public class ProtocolKissTest {
 
     @Test
     public void deviceStateParsesPackedFirmwareStruct() {
-        java.nio.ByteBuffer payload = java.nio.ByteBuffer.allocate(22).order(java.nio.ByteOrder.LITTLE_ENDIAN);
+        java.nio.ByteBuffer payload = java.nio.ByteBuffer.allocate(26).order(java.nio.ByteOrder.LITTLE_ENDIAN);
         payload.putInt(9);
+        payload.putInt(42);
         payload.putShort((short) (Protocol.HOST_STATE_RADIO_CONFIG_VALID | Protocol.DEVICE_STATE_TX_ACTIVE));
         payload.put(Protocol.DRA818_12K5);
         payload.putFloat(144.3900f);
@@ -317,6 +334,7 @@ public class ProtocolKissTest {
 
         assertTrue(parsed.isPresent());
         assertEquals(9, parsed.get().getAppliedSequence());
+        assertEquals(42, parsed.get().getMemoryId());
         assertEquals(Protocol.DeviceMode.DEVICE_MODE_TX, parsed.get().getMode());
         assertEquals(Protocol.RadioStatus.RADIO_STATUS_FOUND, parsed.get().getRadioModuleStatus());
         assertEquals(123, parsed.get().getLatestRssi());

--- a/android-src/KV4PHT/app/src/test/java/com/vagell/kv4pht/radio/ProtocolKissTest.java
+++ b/android-src/KV4PHT/app/src/test/java/com/vagell/kv4pht/radio/ProtocolKissTest.java
@@ -42,6 +42,22 @@ public class ProtocolKissTest {
     }
 
     @Test
+    public void encoderUsesOnlyProvidedPayloadLength() {
+        byte[] frame = Protocol.buildKissFrame(
+            Protocol.KISS_CMD_DATA,
+            new byte[]{0x11, 0x22, (byte) Protocol.KISS_FEND, (byte) Protocol.KISS_FESC},
+            2);
+
+        assertArrayEquals(new byte[]{
+            (byte) Protocol.KISS_FEND,
+            Protocol.KISS_CMD_DATA,
+            0x11,
+            0x22,
+            (byte) Protocol.KISS_FEND,
+        }, frame);
+    }
+
+    @Test
     public void parserUnescapesDataFrameAndDispatchesAx25() {
         Protocol.KissParser parser = newParser();
         parser.processBytes(new byte[]{
@@ -142,6 +158,21 @@ public class ProtocolKissTest {
         assertEquals(Protocol.RcvCommand.COMMAND_SMETER_REPORT, command);
         assertEquals(commandPayload.length, payloadLen);
         assertArrayEquals(commandPayload, payload);
+    }
+
+    @Test
+    public void rxAudioVendorFrameUnescapesAndDispatchesPayload() {
+        byte[] audioPayload = new byte[]{0x11, (byte) Protocol.KISS_FEND, 0x22, (byte) Protocol.KISS_FESC};
+        byte[] frame = Protocol.buildKissFrame(
+            Protocol.KISS_CMD_SETHARDWARE,
+            Protocol.buildKv4pVendorPayload(Protocol.RcvCommand.COMMAND_RX_AUDIO.getValue(), audioPayload));
+
+        newParser().processBytes(frame);
+
+        assertTrue(called);
+        assertEquals(Protocol.RcvCommand.COMMAND_RX_AUDIO, command);
+        assertEquals(audioPayload.length, payloadLen);
+        assertArrayEquals(audioPayload, payload);
     }
 
     @Test

--- a/android-src/KV4PHT/app/src/test/java/com/vagell/kv4pht/radio/ProtocolKissTest.java
+++ b/android-src/KV4PHT/app/src/test/java/com/vagell/kv4pht/radio/ProtocolKissTest.java
@@ -314,6 +314,43 @@ public class ProtocolKissTest {
     }
 
     @Test
+    public void radioModuleControllerRetriesLastDesiredStateWhenDeviceStateDoesNotMatch() {
+        CapturingSender sender = new CapturingSender();
+        RadioModuleController controller = new RadioModuleController();
+        controller.attachSender(sender);
+        Protocol.DeviceState initialState = Protocol.DeviceState.builder()
+            .appliedSequence(7)
+            .memoryId(42)
+            .flags(Protocol.HOST_STATE_RADIO_CONFIG_VALID
+                | Protocol.HOST_STATE_HIGH_POWER
+                | Protocol.HOST_STATE_RSSI_ENABLED)
+            .bw(Protocol.DRA818_25K)
+            .freqTx(146.5200f)
+            .freqRx(146.5200f)
+            .ctcssTx((byte) 0)
+            .squelch((byte) 1)
+            .ctcssRx((byte) 0)
+            .radioModuleStatus(Protocol.RadioStatus.RADIO_STATUS_FOUND)
+            .mode(Protocol.DeviceMode.DEVICE_MODE_STOPPED)
+            .lastError(0)
+            .latestRssi(0)
+            .build();
+
+        controller.seedFromDeviceState(initialState);
+        controller.markTransportReady();
+        controller.openAudio();
+
+        assertEquals(1, sender.sentStates.size());
+        Protocol.HostDesiredState firstSend = sender.sentStates.get(0);
+        controller.updateDeviceState(initialState);
+
+        assertEquals(2, sender.sentStates.size());
+        Protocol.HostDesiredState retry = sender.sentStates.get(1);
+        assertEquals(firstSend.getSequence(), retry.getSequence());
+        assertEquals(firstSend, retry);
+    }
+
+    @Test
     public void deviceStateParsesPackedFirmwareStruct() {
         java.nio.ByteBuffer payload = java.nio.ByteBuffer.allocate(26).order(java.nio.ByteOrder.LITTLE_ENDIAN);
         payload.putInt(9);

--- a/android-src/KV4PHT/app/src/test/java/com/vagell/kv4pht/radio/ProtocolKissTest.java
+++ b/android-src/KV4PHT/app/src/test/java/com/vagell/kv4pht/radio/ProtocolKissTest.java
@@ -1,0 +1,187 @@
+package com.vagell.kv4pht.radio;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class ProtocolKissTest {
+    private boolean called;
+    private Protocol.RcvCommand command;
+    private byte[] payload;
+    private int payloadLen;
+
+    @Before
+    public void setUp() {
+        called = false;
+        command = Protocol.RcvCommand.COMMAND_RCV_UNKNOWN;
+        payload = new byte[0];
+        payloadLen = 0;
+    }
+
+    @Test
+    public void encoderEscapesFendAndFesc() {
+        byte[] frame = Protocol.buildKissFrame(
+            Protocol.KISS_CMD_DATA,
+            new byte[]{0x11, (byte) Protocol.KISS_FEND, 0x22, (byte) Protocol.KISS_FESC});
+
+        assertArrayEquals(new byte[]{
+            (byte) Protocol.KISS_FEND,
+            Protocol.KISS_CMD_DATA,
+            0x11,
+            (byte) Protocol.KISS_FESC,
+            (byte) Protocol.KISS_TFEND,
+            0x22,
+            (byte) Protocol.KISS_FESC,
+            (byte) Protocol.KISS_TFESC,
+            (byte) Protocol.KISS_FEND,
+        }, frame);
+    }
+
+    @Test
+    public void parserUnescapesDataFrameAndDispatchesAx25() {
+        Protocol.KissParser parser = newParser();
+        parser.processBytes(new byte[]{
+            (byte) Protocol.KISS_FEND,
+            Protocol.KISS_CMD_DATA,
+            0x11,
+            (byte) Protocol.KISS_FESC,
+            (byte) Protocol.KISS_TFEND,
+            0x22,
+            (byte) Protocol.KISS_FESC,
+            (byte) Protocol.KISS_TFESC,
+            (byte) Protocol.KISS_FEND,
+        });
+
+        assertTrue(called);
+        assertEquals(Protocol.RcvCommand.COMMAND_RX_AX25_PACKET, command);
+        assertEquals(4, payloadLen);
+        assertArrayEquals(new byte[]{0x11, (byte) Protocol.KISS_FEND, 0x22, (byte) Protocol.KISS_FESC}, payload);
+    }
+
+    @Test
+    public void parserIgnoresMultipleFendBytes() {
+        Protocol.KissParser parser = newParser();
+        parser.processBytes(new byte[]{
+            (byte) Protocol.KISS_FEND,
+            (byte) Protocol.KISS_FEND,
+            Protocol.KISS_CMD_SETHARDWARE,
+            'K', 'V', '4', 'P',
+            Protocol.KV4P_PROTOCOL_VERSION,
+            (byte) Protocol.RcvCommand.COMMAND_HELLO.getValue(),
+            (byte) Protocol.KISS_FEND,
+        });
+
+        assertTrue(called);
+        assertEquals(Protocol.RcvCommand.COMMAND_HELLO, command);
+        assertEquals(0, payloadLen);
+    }
+
+    @Test
+    public void parserValidatesVendorPrefixAndVersion() {
+        Protocol.KissParser parser = newParser();
+        parser.processBytes(Protocol.buildKissFrame(
+            Protocol.KISS_CMD_SETHARDWARE,
+            new byte[]{'B', 'A', 'D', '!', Protocol.KV4P_PROTOCOL_VERSION, (byte) Protocol.RcvCommand.COMMAND_HELLO.getValue()}));
+
+        assertFalse(called);
+
+        parser = newParser();
+        parser.processBytes(Protocol.buildKissFrame(
+            Protocol.KISS_CMD_SETHARDWARE,
+            new byte[]{'K', 'V', '4', 'P', 0x02, (byte) Protocol.RcvCommand.COMMAND_HELLO.getValue()}));
+
+        assertFalse(called);
+    }
+
+    @Test
+    public void parserDropsOverMtuDataFrame() {
+        Protocol.KissParser parser = newParser();
+        byte[] frame = new byte[Protocol.PROTO_MTU + 4];
+        frame[0] = (byte) Protocol.KISS_FEND;
+        frame[1] = Protocol.KISS_CMD_DATA;
+        for (int i = 2; i < frame.length - 1; i++) {
+            frame[i] = 0x55;
+        }
+        frame[frame.length - 1] = (byte) Protocol.KISS_FEND;
+
+        parser.processBytes(frame);
+
+        assertFalse(called);
+    }
+
+    @Test
+    public void parserDropsUnknownEscape() {
+        Protocol.KissParser parser = newParser();
+        parser.processBytes(new byte[]{
+            (byte) Protocol.KISS_FEND,
+            Protocol.KISS_CMD_DATA,
+            0x11,
+            (byte) Protocol.KISS_FESC,
+            (byte) 0x99,
+            0x22,
+            (byte) Protocol.KISS_FEND,
+        });
+
+        assertFalse(called);
+    }
+
+    @Test
+    public void vendorFrameRoundTripsCommandPayloadWithoutTopLevelLength() {
+        byte[] commandPayload = new byte[]{0x01, 0x02, 0x03};
+        byte[] frame = Protocol.buildKissFrame(
+            Protocol.KISS_CMD_SETHARDWARE,
+            Protocol.buildKv4pVendorPayload(Protocol.RcvCommand.COMMAND_SMETER_REPORT.getValue(), commandPayload));
+
+        newParser().processBytes(frame);
+
+        assertTrue(called);
+        assertEquals(Protocol.RcvCommand.COMMAND_SMETER_REPORT, command);
+        assertEquals(commandPayload.length, payloadLen);
+        assertArrayEquals(commandPayload, payload);
+    }
+
+    @Test
+    public void firmwareVersionParsesSingleFeaturesByte() {
+        byte[] payload = new byte[]{
+            0x10, 0x00,                  // firmware version 16
+            'f',                         // radio module found
+            0x00, 0x08, 0x00, 0x00,      // window size 2048
+            0x01, 0x00, 0x00, 0x00,      // UHF module
+            0x03,                        // has HL + physical PTT
+        };
+
+        java.util.Optional<Protocol.FirmwareVersion> parsed = Protocol.FirmwareVersion.from(payload, payload.length);
+
+        assertTrue(parsed.isPresent());
+        assertEquals(16, parsed.get().getVer());
+        assertEquals(2048, parsed.get().getWindowSize());
+        assertEquals(Protocol.RfModuleType.RF_SA818_UHF, parsed.get().getModuleType());
+        assertTrue(parsed.get().isHasHl());
+        assertTrue(parsed.get().isHasPhysPtt());
+    }
+
+    @Test
+    public void firmwareVersionRejectsMismatchedLengthWithoutThrowing() {
+        byte[] shortPayload = new byte[]{
+            0x10, 0x00,
+            'f',
+            0x00, 0x08, 0x00, 0x00,
+            0x01, 0x00, 0x00, 0x00,
+        };
+
+        assertFalse(Protocol.FirmwareVersion.from(shortPayload, 12).isPresent());
+    }
+
+    private Protocol.KissParser newParser() {
+        return new Protocol.KissParser((cmd, param, len) -> {
+            called = true;
+            command = cmd;
+            payloadLen = len;
+            payload = java.util.Arrays.copyOf(param, len);
+        });
+    }
+}

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/buttons.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/buttons.h
@@ -38,7 +38,7 @@ void inline buttonsLoop() {
     bool debouncedPttState = pttDebounce.debounce(digitalRead(hw.pins.pinPttPhys1) == LOW || digitalRead(hw.pins.pinPttPhys2) == LOW);
     if (debouncedPttState != isPhysPttDown) {
       isPhysPttDown = debouncedPttState;
-      sendCurrentDeviceState();
+      markDeviceStateDirty();
     }
   }
 }

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/buttons.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/buttons.h
@@ -38,7 +38,7 @@ void inline buttonsLoop() {
     bool debouncedPttState = pttDebounce.debounce(digitalRead(hw.pins.pinPttPhys1) == LOW || digitalRead(hw.pins.pinPttPhys2) == LOW);
     if (debouncedPttState != isPhysPttDown) {
       isPhysPttDown = debouncedPttState;
-      sendPhysPttState(isPhysPttDown);
+      sendCurrentDeviceState();
     }
   }
 }

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/debug.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/debug.h
@@ -77,7 +77,7 @@ int debug_log_printf(SndCommand cmd, const char* format, ...) {
     }
   }
   vsnprintf(temp, len + 1, format, arg);
-  __sendCmdToHost(cmd, (byte*) temp, len);
+  sendKv4pVendorFrame(cmd, (byte*) temp, len);
   va_end(arg);
   if (len >= sizeof(loc_buf)) {
     free(temp);

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/globals.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/globals.h
@@ -82,6 +82,7 @@ bool squelched = false;
 void setMode(Mode newMode);
 Mode rxIdleMode();
 void sendCurrentDeviceState();
+void markDeviceStateDirty();
 
 struct [[gnu::packed]] RGBColor {
   uint8_t red;

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/globals.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/globals.h
@@ -80,6 +80,8 @@ bool squelched = false;
 
 // Forward declarations
 void setMode(Mode newMode);
+Mode rxIdleMode();
+void sendCurrentDeviceState();
 
 struct [[gnu::packed]] RGBColor {
   uint8_t red;

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
@@ -48,6 +48,7 @@ boolean rssiOn = true; // true if RSSI is enabled
 boolean audioOpen = false; // true when host wants RX Opus audio frames
 HostDesiredState desiredState = {
   .sequence = 0,
+  .memoryId = -1,
   .flags = HOST_STATE_HIGH_POWER | HOST_STATE_RSSI_ENABLED,
   .bw = DRA818_25K,
   .freq_tx = 0.0f,
@@ -65,6 +66,22 @@ bool hasPersistedRadioState = false;
 
 Debounce squelchDebounce(100);
 
+float moduleMinRadioFreq() {
+  return hw.rfModuleType == RF_SA818_UHF ? 400.0f : 134.0f;
+}
+
+float moduleMaxRadioFreq() {
+  return hw.rfModuleType == RF_SA818_UHF ? 480.0f : 174.0f;
+}
+
+float clampModuleRadioFreq(float freq) {
+  return min(max(freq, moduleMinRadioFreq()), moduleMaxRadioFreq());
+}
+
+bool isModuleRadioFreq(float freq) {
+  return freq >= moduleMinRadioFreq() && freq <= moduleMaxRadioFreq();
+}
+
 void loadPersistedRadioState() {
   prefs.begin("radio", true);
   hasPersistedRadioState = prefs.getBool("valid", false);
@@ -78,6 +95,12 @@ void loadPersistedRadioState() {
     desiredState.ctcss_tx = prefs.getUChar("ctcss_tx", 0);
     desiredState.squelch = prefs.getUChar("squelch", 0);
     desiredState.ctcss_rx = prefs.getUChar("ctcss_rx", 0);
+    desiredState.memoryId = prefs.getInt("memory_id", -1);
+    if (!isModuleRadioFreq(desiredState.freq_tx) || !isModuleRadioFreq(desiredState.freq_rx)) {
+      desiredState.freq_tx = clampModuleRadioFreq(desiredState.freq_tx);
+      desiredState.freq_rx = clampModuleRadioFreq(desiredState.freq_rx);
+      desiredState.memoryId = -1;
+    }
   }
   if (prefs.getBool("high", true)) {
     flags |= HOST_STATE_HIGH_POWER;
@@ -97,6 +120,7 @@ void loadPersistedRadioState() {
   desiredState.flags = flags;
   desiredState.sequence = 0;
   desiredState.flags &= ~(HOST_STATE_PTT_REQUESTED | HOST_STATE_RX_AUDIO_OPEN);
+  appliedState.memoryId = desiredState.memoryId;
   prefs.end();
 }
 
@@ -109,6 +133,7 @@ bool persistedRadioStateMatchesDesired() {
     && prefs.getUChar("ctcss_tx", 0) == desiredState.ctcss_tx
     && prefs.getUChar("squelch", 0) == desiredState.squelch
     && prefs.getUChar("ctcss_rx", 0) == desiredState.ctcss_rx
+    && prefs.getInt("memory_id", -1) == desiredState.memoryId
     && prefs.getBool("high", true) == ((desiredState.flags & HOST_STATE_HIGH_POWER) != 0)
     && prefs.getBool("rssi", true) == ((desiredState.flags & HOST_STATE_RSSI_ENABLED) != 0)
     && prefs.getBool("flt_pre", false) == ((desiredState.flags & HOST_STATE_FILTER_PRE) != 0)
@@ -130,6 +155,7 @@ void savePersistedRadioStateIfChanged() {
   prefs.putUChar("ctcss_tx", desiredState.ctcss_tx);
   prefs.putUChar("squelch", desiredState.squelch);
   prefs.putUChar("ctcss_rx", desiredState.ctcss_rx);
+  prefs.putInt("memory_id", desiredState.memoryId);
   prefs.putBool("high", (desiredState.flags & HOST_STATE_HIGH_POWER) != 0);
   prefs.putBool("rssi", (desiredState.flags & HOST_STATE_RSSI_ENABLED) != 0);
   prefs.putBool("flt_pre", (desiredState.flags & HOST_STATE_FILTER_PRE) != 0);
@@ -181,6 +207,7 @@ uint8_t deviceMode() {
 DeviceState currentDeviceState() {
   return {
     .appliedSequence = desiredState.sequence,
+    .memoryId = appliedState.memoryId,
     .flags = deviceStateFlags(),
     .bw = appliedState.bw,
     .freq_tx = appliedState.freq_tx,
@@ -206,7 +233,8 @@ bool radioConfigChanged() {
     || appliedState.freq_rx != desiredState.freq_rx
     || appliedState.ctcss_tx != desiredState.ctcss_tx
     || appliedState.squelch != desiredState.squelch
-    || appliedState.ctcss_rx != desiredState.ctcss_rx;
+    || appliedState.ctcss_rx != desiredState.ctcss_rx
+    || appliedState.memoryId != desiredState.memoryId;
 }
 
 void reconcileDesiredState(bool sendReport = true) {
@@ -240,6 +268,7 @@ void reconcileDesiredState(bool sendReport = true) {
     appliedState.ctcss_tx = desiredState.ctcss_tx;
     appliedState.squelch = desiredState.squelch;
     appliedState.ctcss_rx = desiredState.ctcss_rx;
+    appliedState.memoryId = desiredState.memoryId;
     appliedState.flags |= HOST_STATE_RADIO_CONFIG_VALID;
     radioConfigApplied = true;
   }
@@ -326,7 +355,7 @@ void setup() {
   if (radioModuleStatus == RADIO_MODULE_FOUND) {
     reconcileDesiredState(false);
   }
-  sendHello(FIRMWARE_VER, radioModuleStatus, USB_BUFFER_SIZE, hw.rfModuleType, getFirmwareFeatures(), currentDeviceState());
+  sendHello(FIRMWARE_VER, radioModuleStatus, USB_BUFFER_SIZE, hw.rfModuleType, moduleMinRadioFreq(), moduleMaxRadioFreq(), getFirmwareFeatures(), currentDeviceState());
   _LOGI("Setup is finished");
 }
 

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
@@ -32,6 +32,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 const uint16_t FIRMWARE_VER = 16;
 
 const uint32_t RSSI_REPORT_INTERVAL_MS = 100;
+const uint32_t DEVICE_STATE_REPORT_INTERVAL_MS = 500;
 const uint16_t USB_BUFFER_SIZE = 1024*2;
 
 DRA818 sa818_vhf(&Serial2, SA818_VHF);
@@ -44,8 +45,135 @@ const char RADIO_MODULE_FOUND     = 'f';
 char radioModuleStatus            = RADIO_MODULE_NOT_FOUND;
 
 boolean rssiOn = true; // true if RSSI is enabled
+boolean audioOpen = false; // true when host wants RX Opus audio frames
+HostDesiredState desiredState = {
+  .sequence = 0,
+  .flags = HOST_STATE_HIGH_POWER | HOST_STATE_RSSI_ENABLED,
+  .bw = DRA818_25K,
+  .freq_tx = 0.0f,
+  .freq_rx = 0.0f,
+  .ctcss_tx = 0,
+  .squelch = 0,
+  .ctcss_rx = 0,
+};
+HostDesiredState appliedState = {};
+bool radioConfigApplied = false;
+bool filtersApplied = false;
+uint8_t lastDeviceStateError = DEVICE_STATE_ERROR_NONE;
+uint8_t latestRssi = 0;
 
 Debounce squelchDebounce(100);
+
+uint8_t getFirmwareFeatures() {
+  return (hw.features.hasHL ? FEATURE_HAS_HL : 0)
+    | (hw.features.hasPhysPTT ? FEATURE_HAS_PHY_PTT : 0)
+    | FEATURE_HAS_ESP32_AFSK;
+}
+
+Mode rxIdleMode() {
+  return audioOpen ? MODE_RX : MODE_STOPPED;
+}
+
+uint16_t desiredFilterFlags() {
+  return desiredState.flags & (HOST_STATE_FILTER_PRE | HOST_STATE_FILTER_HIGH | HOST_STATE_FILTER_LOW);
+}
+
+uint16_t deviceStateFlags() {
+  uint16_t flags = desiredState.flags;
+  if (isPhysPttDown) {
+    flags |= DEVICE_STATE_PHYS_PTT_DOWN;
+  }
+  if (mode == MODE_TX) {
+    flags |= DEVICE_STATE_TX_ACTIVE;
+  }
+  if (squelched) {
+    flags |= DEVICE_STATE_SQUELCHED;
+  }
+  return flags;
+}
+
+uint8_t deviceMode() {
+  switch (mode) {
+    case MODE_TX:
+      return DEVICE_MODE_TX;
+    case MODE_RX:
+      return DEVICE_MODE_RX;
+    case MODE_STOPPED:
+    default:
+      return DEVICE_MODE_STOPPED;
+  }
+}
+
+void sendCurrentDeviceState() {
+  DeviceState state = {
+    .appliedSequence = desiredState.sequence,
+    .flags = deviceStateFlags(),
+    .bw = appliedState.bw,
+    .freq_tx = appliedState.freq_tx,
+    .freq_rx = appliedState.freq_rx,
+    .ctcss_tx = appliedState.ctcss_tx,
+    .squelch = appliedState.squelch,
+    .ctcss_rx = appliedState.ctcss_rx,
+    .radioModuleStatus = radioModuleStatus,
+    .mode = deviceMode(),
+    .lastError = lastDeviceStateError,
+    .latestRssi = latestRssi,
+  };
+  sendDeviceState(state);
+}
+
+bool radioConfigChanged() {
+  return !radioConfigApplied
+    || appliedState.bw != desiredState.bw
+    || appliedState.freq_tx != desiredState.freq_tx
+    || appliedState.freq_rx != desiredState.freq_rx
+    || appliedState.ctcss_tx != desiredState.ctcss_tx
+    || appliedState.squelch != desiredState.squelch
+    || appliedState.ctcss_rx != desiredState.ctcss_rx;
+}
+
+void reconcileDesiredState() {
+  lastDeviceStateError = DEVICE_STATE_ERROR_NONE;
+  bool wantHigh = desiredState.flags & HOST_STATE_HIGH_POWER;
+  if (hw.features.hasHL) {
+    digitalWrite(hw.pins.pinHl, wantHigh ? LOW : HIGH);
+  }
+  rssiOn = desiredState.flags & HOST_STATE_RSSI_ENABLED;
+  audioOpen = desiredState.flags & HOST_STATE_RX_AUDIO_OPEN;
+
+  uint16_t filterFlags = desiredFilterFlags();
+  uint16_t appliedFilterFlags = appliedState.flags & (HOST_STATE_FILTER_PRE | HOST_STATE_FILTER_HIGH | HOST_STATE_FILTER_LOW);
+  if (!filtersApplied || filterFlags != appliedFilterFlags) {
+    while (!sa818.filters((filterFlags & HOST_STATE_FILTER_PRE), (filterFlags & HOST_STATE_FILTER_HIGH), (filterFlags & HOST_STATE_FILTER_LOW))) {
+      lastDeviceStateError = DEVICE_STATE_ERROR_FILTERS_FAILED;
+      esp_task_wdt_reset();
+    }
+    appliedState.flags = (appliedState.flags & ~(HOST_STATE_FILTER_PRE | HOST_STATE_FILTER_HIGH | HOST_STATE_FILTER_LOW)) | filterFlags;
+    filtersApplied = true;
+  }
+
+  if ((desiredState.flags & HOST_STATE_RADIO_CONFIG_VALID) && radioConfigChanged()) {
+    while (!sa818.group(desiredState.bw, desiredState.freq_tx, desiredState.freq_rx, desiredState.ctcss_tx, desiredState.squelch, desiredState.ctcss_rx)) {
+      lastDeviceStateError = DEVICE_STATE_ERROR_RADIO_CONFIG_FAILED;
+      esp_task_wdt_reset();
+    }
+    appliedState.bw = desiredState.bw;
+    appliedState.freq_tx = desiredState.freq_tx;
+    appliedState.freq_rx = desiredState.freq_rx;
+    appliedState.ctcss_tx = desiredState.ctcss_tx;
+    appliedState.squelch = desiredState.squelch;
+    appliedState.ctcss_rx = desiredState.ctcss_rx;
+    appliedState.flags |= HOST_STATE_RADIO_CONFIG_VALID;
+    radioConfigApplied = true;
+  }
+
+  if (desiredState.flags & HOST_STATE_PTT_REQUESTED) {
+    setMode(MODE_TX);
+  } else {
+    setMode(rxIdleMode());
+  }
+  sendCurrentDeviceState();
+}
 
 void setMode(Mode newMode) {
   if (mode == newMode) {
@@ -57,7 +185,7 @@ void setMode(Mode newMode) {
       _LOGI("MODE_STOPPED");
       digitalWrite(hw.pins.pinPtt, HIGH);
       endI2STx();
-      endI2SRx();
+      initI2SRx();
     break;
     case MODE_RX:
       _LOGI("MODE_RX");
@@ -111,19 +239,21 @@ void setup() {
   // Begin in STOPPED mode
   squelched = (digitalRead(hw.pins.pinSq) == HIGH);
   setMode(MODE_STOPPED);
+  initI2SRx();
   ledSetup();
-  sendHello();
+  initRadio(true);
+  sendHello(FIRMWARE_VER, radioModuleStatus, USB_BUFFER_SIZE, hw.rfModuleType, getFirmwareFeatures());
   _LOGI("Setup is finished");
 }
 
-void doConfig(Config const &config) {
+void initRadio(bool isHigh) {
   if (hw.rfModuleType == RF_SA818_UHF) {
     sa818 = sa818_uhf;
   } else {
     sa818 = sa818_vhf;
   }
   if (hw.features.hasHL) {
-    digitalWrite(hw.pins.pinHl, config.isHigh ? LOW : HIGH);
+    digitalWrite(hw.pins.pinHl, isHigh ? LOW : HIGH);
   }
   radioModuleStatus = RADIO_MODULE_NOT_FOUND;
   // The sa818.handshake() has 3 retries internally with 2 seconds between each attempt.
@@ -138,87 +268,34 @@ void doConfig(Config const &config) {
       break;
     }
   }
-  uint8_t features = (hw.features.hasHL ? FEATURE_HAS_HL : 0)
-    | (hw.features.hasPhysPTT ? FEATURE_HAS_PHY_PTT : 0)
-    | FEATURE_HAS_ESP32_AFSK;
-  sendVersion(FIRMWARE_VER, radioModuleStatus, USB_BUFFER_SIZE, hw.rfModuleType, features);
-  esp_task_wdt_reset();
 }
 
 void handleCommands(RcvCommand command, uint8_t *params, size_t param_len) {
   switch (command) {
-    case COMMAND_HOST_CONFIG:
-      if (param_len == sizeof(Config)) {
-        Config config;
-        memcpy(&config, params, sizeof(Config));
-        doConfig(config);
-        esp_task_wdt_reset();
-      }
-      break;
-    case COMMAND_HOST_FILTERS:
-      if (param_len == sizeof(Filters)) {
-        Filters filters;
-        memcpy(&filters, params, sizeof(Filters));
-        while (!sa818.filters((filters.flags & FILTER_PRE), (filters.flags & FILTER_HIGH), (filters.flags & FILTER_LOW)));
-        esp_task_wdt_reset();
-      }
-      break;
-    case COMMAND_HOST_GROUP:
-      if (param_len == sizeof(Group)) {
-        Group group;
-        memcpy(&group, params, sizeof(Group));
-        while (!sa818.group(group.bw, group.freq_tx, group.freq_rx, group.ctcss_tx, group.squelch, group.ctcss_rx));
-        esp_task_wdt_reset();
-        if (mode == MODE_STOPPED) {
-          setMode(MODE_RX);   
-        }
-      } 
-      break;
-    case COMMAND_HOST_STOP:
-      setMode(MODE_STOPPED);
-      esp_task_wdt_reset();
-      break;
-    case COMMAND_HOST_PTT_DOWN:
-      setMode(MODE_TX);
-      esp_task_wdt_reset();
-      break;
-    case COMMAND_HOST_PTT_UP:
-      setMode(MODE_RX);
-      esp_task_wdt_reset();
-      break;
     case COMMAND_HOST_TX_AUDIO:
       if (mode == MODE_TX) {
         processTxAudio(params, param_len);
         esp_task_wdt_reset();
       }
       break;
-    case COMMAND_HOST_HL:
-      if (param_len == sizeof(HlState)) {
-        HlState hl;
-        memcpy(&hl, params, sizeof(HlState));
-        if (hw.features.hasHL) {
-          digitalWrite(hw.pins.pinHl, hl.isHigh ? LOW : HIGH);
-        }
-        esp_task_wdt_reset();
-      }
-      break;     
-    case COMMAND_HOST_RSSI:
-      if (param_len == sizeof(RSSIState)) {
-        RSSIState rssiState;
-        memcpy(&rssiState, params, sizeof(RSSIState));
-        rssiState.on ? rssiOn = true : rssiOn = false;    
-      }   
-      break;                    
-    case COMMAND_HOST_TX_AX25:
-      if (param_len > 0 && param_len <= PROTO_MTU) {
-        setMode(MODE_TX);
-        digitalWrite(hw.pins.pinLed, HIGH);
-        neopixelColor(COLOR_TX);
-        processTxAx25(params, param_len);
-        setMode(MODE_RX);
+    case COMMAND_HOST_DESIRED_STATE:
+      if (param_len == sizeof(HostDesiredState)) {
+        memcpy(&desiredState, params, sizeof(HostDesiredState));
+        reconcileDesiredState();
         esp_task_wdt_reset();
       }
       break;
+  }
+}
+
+void handleAx25Data(uint8_t *ax25, size_t ax25_len) {
+  if (ax25_len > 0 && ax25_len <= PROTO_MTU) {
+    setMode(MODE_TX);
+    digitalWrite(hw.pins.pinLed, HIGH);
+    neopixelColor(COLOR_TX);
+    processTxAx25(ax25, ax25_len);
+    setMode(rxIdleMode());
+    esp_task_wdt_reset();
   }
 }
 
@@ -234,12 +311,23 @@ void rssiLoop() {
         String rssiStr = rssiResponse.substring(5);
         int rssiInt    = rssiStr.toInt();
         if (rssiInt >= 0 && rssiInt <= 255) {
-          sendRssi((uint8_t)rssiInt);
+          uint8_t rssi = (uint8_t)rssiInt;
+          if (latestRssi != rssi) {
+            latestRssi = rssi;
+            sendCurrentDeviceState();
+          }
         }
       }
     }
     END_EVERY_N_MILLISECONDS();
   }
+}
+
+void deviceStateLoop() {
+  EVERY_N_MILLISECONDS(DEVICE_STATE_REPORT_INTERVAL_MS) {
+    sendCurrentDeviceState();
+  }
+  END_EVERY_N_MILLISECONDS();
 }
 
 void loop() {
@@ -251,4 +339,5 @@ void loop() {
   rxAudioLoop();
   txAudioLoop();
   rssiLoop();
+  deviceStateLoop();
 }

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
@@ -63,6 +63,7 @@ bool filtersApplied = false;
 uint8_t lastDeviceStateError = DEVICE_STATE_ERROR_NONE;
 uint8_t latestRssi = 0;
 bool hasPersistedRadioState = false;
+bool deviceStateDirty = false;
 
 Debounce squelchDebounce(100);
 
@@ -224,6 +225,11 @@ DeviceState currentDeviceState() {
 
 void sendCurrentDeviceState() {
   sendDeviceState(currentDeviceState());
+  deviceStateDirty = false;
+}
+
+void markDeviceStateDirty() {
+  deviceStateDirty = true;
 }
 
 bool radioConfigChanged() {
@@ -280,7 +286,7 @@ void reconcileDesiredState(bool sendReport = true) {
   }
   savePersistedRadioStateIfChanged();
   if (sendReport) {
-    sendCurrentDeviceState();
+    markDeviceStateDirty();
   }
 }
 
@@ -427,7 +433,7 @@ void rssiLoop() {
           uint8_t rssi = (uint8_t)rssiInt;
           if (latestRssi != rssi) {
             latestRssi = rssi;
-            sendCurrentDeviceState();
+            markDeviceStateDirty();
           }
         }
       }
@@ -437,14 +443,29 @@ void rssiLoop() {
 }
 
 void deviceStateLoop() {
-  EVERY_N_MILLISECONDS(DEVICE_STATE_REPORT_INTERVAL_MS) {
+  bool sent = false;
+  if (deviceStateDirty) {
     sendCurrentDeviceState();
+    sent = true;
+  }
+  EVERY_N_MILLISECONDS(DEVICE_STATE_REPORT_INTERVAL_MS) {
+    if (!sent) {
+      sendCurrentDeviceState();
+    }
   }
   END_EVERY_N_MILLISECONDS();
 }
 
+void squelchLoop() {
+  bool nextSquelched = squelchDebounce.debounce((digitalRead(hw.pins.pinSq) == HIGH));
+  if (nextSquelched != squelched) {
+    squelched = nextSquelched;
+    markDeviceStateDirty();
+  }
+}
+
 void loop() {
-  squelched = squelchDebounce.debounce((digitalRead(hw.pins.pinSq) == HIGH));
+  squelchLoop();
   debugLoop();
   ledLoop();
   buttonsLoop();

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
@@ -61,8 +61,82 @@ bool radioConfigApplied = false;
 bool filtersApplied = false;
 uint8_t lastDeviceStateError = DEVICE_STATE_ERROR_NONE;
 uint8_t latestRssi = 0;
+bool hasPersistedRadioState = false;
 
 Debounce squelchDebounce(100);
+
+void loadPersistedRadioState() {
+  prefs.begin("radio", true);
+  hasPersistedRadioState = prefs.getBool("valid", false);
+  uint16_t flags = desiredState.flags;
+  flags &= ~(HOST_STATE_RADIO_CONFIG_VALID | HOST_STATE_HIGH_POWER | HOST_STATE_RSSI_ENABLED | HOST_STATE_FILTER_PRE | HOST_STATE_FILTER_HIGH | HOST_STATE_FILTER_LOW);
+  if (hasPersistedRadioState) {
+    flags |= HOST_STATE_RADIO_CONFIG_VALID;
+    desiredState.bw = prefs.getUChar("bw", DRA818_25K);
+    desiredState.freq_tx = prefs.getFloat("freq_tx", 0.0f);
+    desiredState.freq_rx = prefs.getFloat("freq_rx", 0.0f);
+    desiredState.ctcss_tx = prefs.getUChar("ctcss_tx", 0);
+    desiredState.squelch = prefs.getUChar("squelch", 0);
+    desiredState.ctcss_rx = prefs.getUChar("ctcss_rx", 0);
+  }
+  if (prefs.getBool("high", true)) {
+    flags |= HOST_STATE_HIGH_POWER;
+  }
+  if (prefs.getBool("rssi", true)) {
+    flags |= HOST_STATE_RSSI_ENABLED;
+  }
+  if (prefs.getBool("flt_pre", false)) {
+    flags |= HOST_STATE_FILTER_PRE;
+  }
+  if (prefs.getBool("flt_high", false)) {
+    flags |= HOST_STATE_FILTER_HIGH;
+  }
+  if (prefs.getBool("flt_low", false)) {
+    flags |= HOST_STATE_FILTER_LOW;
+  }
+  desiredState.flags = flags;
+  desiredState.sequence = 0;
+  desiredState.flags &= ~(HOST_STATE_PTT_REQUESTED | HOST_STATE_RX_AUDIO_OPEN);
+  prefs.end();
+}
+
+bool persistedRadioStateMatchesDesired() {
+  prefs.begin("radio", true);
+  bool matches = prefs.getBool("valid", false) == ((desiredState.flags & HOST_STATE_RADIO_CONFIG_VALID) != 0)
+    && prefs.getUChar("bw", DRA818_25K) == desiredState.bw
+    && prefs.getFloat("freq_tx", 0.0f) == desiredState.freq_tx
+    && prefs.getFloat("freq_rx", 0.0f) == desiredState.freq_rx
+    && prefs.getUChar("ctcss_tx", 0) == desiredState.ctcss_tx
+    && prefs.getUChar("squelch", 0) == desiredState.squelch
+    && prefs.getUChar("ctcss_rx", 0) == desiredState.ctcss_rx
+    && prefs.getBool("high", true) == ((desiredState.flags & HOST_STATE_HIGH_POWER) != 0)
+    && prefs.getBool("rssi", true) == ((desiredState.flags & HOST_STATE_RSSI_ENABLED) != 0)
+    && prefs.getBool("flt_pre", false) == ((desiredState.flags & HOST_STATE_FILTER_PRE) != 0)
+    && prefs.getBool("flt_high", false) == ((desiredState.flags & HOST_STATE_FILTER_HIGH) != 0)
+    && prefs.getBool("flt_low", false) == ((desiredState.flags & HOST_STATE_FILTER_LOW) != 0);
+  prefs.end();
+  return matches;
+}
+
+void savePersistedRadioStateIfChanged() {
+  if (persistedRadioStateMatchesDesired()) {
+    return;
+  }
+  prefs.begin("radio", false);
+  prefs.putBool("valid", (desiredState.flags & HOST_STATE_RADIO_CONFIG_VALID) != 0);
+  prefs.putUChar("bw", desiredState.bw);
+  prefs.putFloat("freq_tx", desiredState.freq_tx);
+  prefs.putFloat("freq_rx", desiredState.freq_rx);
+  prefs.putUChar("ctcss_tx", desiredState.ctcss_tx);
+  prefs.putUChar("squelch", desiredState.squelch);
+  prefs.putUChar("ctcss_rx", desiredState.ctcss_rx);
+  prefs.putBool("high", (desiredState.flags & HOST_STATE_HIGH_POWER) != 0);
+  prefs.putBool("rssi", (desiredState.flags & HOST_STATE_RSSI_ENABLED) != 0);
+  prefs.putBool("flt_pre", (desiredState.flags & HOST_STATE_FILTER_PRE) != 0);
+  prefs.putBool("flt_high", (desiredState.flags & HOST_STATE_FILTER_HIGH) != 0);
+  prefs.putBool("flt_low", (desiredState.flags & HOST_STATE_FILTER_LOW) != 0);
+  prefs.end();
+}
 
 uint8_t getFirmwareFeatures() {
   return (hw.features.hasHL ? FEATURE_HAS_HL : 0)
@@ -104,8 +178,8 @@ uint8_t deviceMode() {
   }
 }
 
-void sendCurrentDeviceState() {
-  DeviceState state = {
+DeviceState currentDeviceState() {
+  return {
     .appliedSequence = desiredState.sequence,
     .flags = deviceStateFlags(),
     .bw = appliedState.bw,
@@ -119,7 +193,10 @@ void sendCurrentDeviceState() {
     .lastError = lastDeviceStateError,
     .latestRssi = latestRssi,
   };
-  sendDeviceState(state);
+}
+
+void sendCurrentDeviceState() {
+  sendDeviceState(currentDeviceState());
 }
 
 bool radioConfigChanged() {
@@ -132,7 +209,7 @@ bool radioConfigChanged() {
     || appliedState.ctcss_rx != desiredState.ctcss_rx;
 }
 
-void reconcileDesiredState() {
+void reconcileDesiredState(bool sendReport = true) {
   lastDeviceStateError = DEVICE_STATE_ERROR_NONE;
   bool wantHigh = desiredState.flags & HOST_STATE_HIGH_POWER;
   if (hw.features.hasHL) {
@@ -172,7 +249,10 @@ void reconcileDesiredState() {
   } else {
     setMode(rxIdleMode());
   }
-  sendCurrentDeviceState();
+  savePersistedRadioStateIfChanged();
+  if (sendReport) {
+    sendCurrentDeviceState();
+  }
 }
 
 void setMode(Mode newMode) {
@@ -206,6 +286,7 @@ void setMode(Mode newMode) {
 
 void setup() {
   boardSetup();
+  loadPersistedRadioState();
   // Communication with Android via USB cable
   Serial.setRxBufferSize(USB_BUFFER_SIZE);
   Serial.setTxBufferSize(USB_BUFFER_SIZE);
@@ -241,8 +322,11 @@ void setup() {
   setMode(MODE_STOPPED);
   initI2SRx();
   ledSetup();
-  initRadio(true);
-  sendHello(FIRMWARE_VER, radioModuleStatus, USB_BUFFER_SIZE, hw.rfModuleType, getFirmwareFeatures());
+  initRadio((desiredState.flags & HOST_STATE_HIGH_POWER) != 0);
+  if (radioModuleStatus == RADIO_MODULE_FOUND) {
+    reconcileDesiredState(false);
+  }
+  sendHello(FIRMWARE_VER, radioModuleStatus, USB_BUFFER_SIZE, hw.rfModuleType, getFirmwareFeatures(), currentDeviceState());
   _LOGI("Setup is finished");
 }
 

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/protocol.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/protocol.h
@@ -65,6 +65,8 @@ struct [[gnu::packed]] Version {
   char         radioModuleStatus;
   size_t       windowSize;
   RfModuleType rfModuleType;
+  float        minRadioFreq;
+  float        maxRadioFreq;
   uint8_t      features; 
 };
 REQUIRE_TRIVIALLY_COPYABLE(Version);
@@ -107,6 +109,7 @@ enum DeviceStateError : uint8_t {
 
 struct [[gnu::packed]] HostDesiredState {
   uint32_t sequence;
+  int32_t memoryId;
   uint16_t flags;
   uint8_t bw;
   float freq_tx;
@@ -119,6 +122,7 @@ REQUIRE_TRIVIALLY_COPYABLE(HostDesiredState);
 
 struct [[gnu::packed]] DeviceState {
   uint32_t appliedSequence;
+  int32_t memoryId;
   uint16_t flags;
   uint8_t bw;
   float freq_tx;
@@ -235,13 +239,15 @@ void sendKv4pVendorFrame(uint8_t kv4pCommand, const uint8_t *payload, size_t len
   writer.end();
 }
 
-void inline sendHello(uint16_t ver, char radioModuleStatus, size_t windowSize, RfModuleType rfModuleType, uint8_t features, const DeviceState &deviceState) {
+void inline sendHello(uint16_t ver, char radioModuleStatus, size_t windowSize, RfModuleType rfModuleType, float minRadioFreq, float maxRadioFreq, uint8_t features, const DeviceState &deviceState) {
   Hello params = {
     .version = {
       .ver = ver,
       .radioModuleStatus = radioModuleStatus,
       .windowSize = windowSize,
       .rfModuleType = rfModuleType,
+      .minRadioFreq = minRadioFreq,
+      .maxRadioFreq = maxRadioFreq,
       .features = features,
     },
     .deviceState = deviceState,

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/protocol.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/protocol.h
@@ -222,14 +222,17 @@ void sendKv4pVendorFrame(uint8_t kv4pCommand, const uint8_t *payload, size_t len
   if (len > PROTO_MTU) {
     len = PROTO_MTU;
   }
-  uint8_t vendorPayload[KV4P_VENDOR_HEADER_LEN + PROTO_MTU];
-  memcpy(vendorPayload, KV4P_VENDOR_PREFIX, sizeof(KV4P_VENDOR_PREFIX));
-  vendorPayload[4] = KV4P_PROTOCOL_VERSION;
-  vendorPayload[5] = kv4pCommand;
-  if (len > 0 && payload != NULL) {
-    memcpy(vendorPayload + KV4P_VENDOR_HEADER_LEN, payload, len);
+  KissBufferedWriter writer(Serial);
+  writer.begin(KISS_CMD_SETHARDWARE);
+  for (size_t i = 0; i < sizeof(KV4P_VENDOR_PREFIX); i++) {
+    writer.writeEscaped(KV4P_VENDOR_PREFIX[i]);
   }
-  sendKissFrame(KISS_CMD_SETHARDWARE, vendorPayload, KV4P_VENDOR_HEADER_LEN + len);
+  writer.writeEscaped(KV4P_PROTOCOL_VERSION);
+  writer.writeEscaped(kv4pCommand);
+  for (size_t i = 0; i < len; i++) {
+    writer.writeEscaped(payload[i]);
+  }
+  writer.end();
 }
 
 void inline sendHello(uint16_t ver, char radioModuleStatus, size_t windowSize, RfModuleType rfModuleType, uint8_t features, const DeviceState &deviceState) {
@@ -254,8 +257,7 @@ void inline sendAudio(const uint8_t *data, size_t len) {
   sendKv4pVendorFrame(COMMAND_RX_AUDIO, data, len);
 }
 
-void inline sendAx25Packet(uint8_t decoderId, const uint8_t *data, size_t len) {
-  (void)decoderId; // KISS DATA frames are pure AX.25; decoder metadata is intentionally not embedded.
+void inline sendAx25Packet(const uint8_t *data, size_t len) {
   sendKissDataFrame(data, len);
 }
 

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/protocol.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/protocol.h
@@ -53,13 +53,13 @@ enum SndCommand {
   COMMAND_DEBUG_WARN     = 0x03, // [COMMAND_DEBUG_WARN(char[])]
   COMMAND_DEBUG_DEBUG    = 0x04, // [COMMAND_DEBUG_DEBUG(char[])]
   COMMAND_DEBUG_TRACE    = 0x05, // [COMMAND_DEBUG_TRACE(char[])]
-  COMMAND_HELLO          = 0x06, // [COMMAND_HELLO(Version)]
+  COMMAND_HELLO          = 0x06, // [COMMAND_HELLO(Hello)]
   COMMAND_RX_AUDIO       = 0x07, // [COMMAND_RX_AUDIO(int8_t[])]
   COMMAND_WINDOW_UPDATE  = 0x09,
   COMMAND_DEVICE_STATE   = 0x0B, // [COMMAND_DEVICE_STATE(DeviceState)]
 };
 
-// COMMAND_HELLO parameters
+// COMMAND_HELLO parameters: Version + initial DeviceState
 struct [[gnu::packed]] Version {
   uint16_t     ver;
   char         radioModuleStatus;
@@ -132,6 +132,12 @@ struct [[gnu::packed]] DeviceState {
   uint8_t latestRssi;
 };
 REQUIRE_TRIVIALLY_COPYABLE(DeviceState);
+
+struct [[gnu::packed]] Hello {
+  Version version;
+  DeviceState deviceState;
+};
+REQUIRE_TRIVIALLY_COPYABLE(Hello);
 
 // COMMAND_WINDOW_ACK parameters
 struct [[gnu::packed]] WindowUpdate {
@@ -226,13 +232,16 @@ void sendKv4pVendorFrame(uint8_t kv4pCommand, const uint8_t *payload, size_t len
   sendKissFrame(KISS_CMD_SETHARDWARE, vendorPayload, KV4P_VENDOR_HEADER_LEN + len);
 }
 
-void inline sendHello(uint16_t ver, char radioModuleStatus, size_t windowSize, RfModuleType rfModuleType, uint8_t features) {
-  Version params = {
-    .ver = ver,
-    .radioModuleStatus = radioModuleStatus,
-    .windowSize = windowSize,
-    .rfModuleType = rfModuleType,
-    .features = features,
+void inline sendHello(uint16_t ver, char radioModuleStatus, size_t windowSize, RfModuleType rfModuleType, uint8_t features, const DeviceState &deviceState) {
+  Hello params = {
+    .version = {
+      .ver = ver,
+      .radioModuleStatus = radioModuleStatus,
+      .windowSize = windowSize,
+      .rfModuleType = rfModuleType,
+      .features = features,
+    },
+    .deviceState = deviceState,
   };
   sendKv4pVendorFrame(COMMAND_HELLO, (uint8_t*) &params, sizeof(params));
 }

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/protocol.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/protocol.h
@@ -41,37 +41,25 @@ static constexpr uint8_t KV4P_VENDOR_PREFIX[] = {'K', 'V', '4', 'P'};
 // Incoming commands (Android -> ESP32)
 enum RcvCommand {
   COMMAND_RCV_UNKNOWN    = 0x00,
-  COMMAND_HOST_PTT_DOWN  = 0x01, // [COMMAND_HOST_PTT_DOWN()]
-  COMMAND_HOST_PTT_UP    = 0x02, // [COMMAND_HOST_PTT_UP()]
-  COMMAND_HOST_GROUP     = 0x03, // [COMMAND_HOST_GROUP(Group)]
-  COMMAND_HOST_FILTERS   = 0x04, // [COMMAND_HOST_FILTERS(Filters)]
-  COMMAND_HOST_STOP      = 0x05, // [COMMAND_HOST_STOP()] 
-  COMMAND_HOST_CONFIG    = 0x06, // [COMMAND_HOST_CONFIG(Config)] -> [COMMAND_VERSION(Version)]
   COMMAND_HOST_TX_AUDIO  = 0x07, // [COMMAND_HOST_TX_AUDIO(uint8_t[])]
-  COMMAND_HOST_HL        = 0x08, // [COMMAND_HOST_HL(Hl)]
-  COMMAND_HOST_RSSI      = 0x09, // [COMMAND_HOST_RSSI(ON)]
-  COMMAND_HOST_TX_AX25   = 0x0A, // [COMMAND_HOST_TX_AX25(uint8_t[])]
+  COMMAND_HOST_DESIRED_STATE = 0x0D, // [COMMAND_HOST_DESIRED_STATE(HostDesiredState)]
 };
 
 // Outgoing commands (ESP32 -> Android)
 enum SndCommand {
   COMMAND_SND_UNKNOWN    = 0x00,
-  COMMAND_SMETER_REPORT  = 0x53, // [COMMAND_SMETER_REPORT(Rssi)]
-  COMMAND_PHYS_PTT_DOWN  = 0x44, // [COMMAND_PHYS_PTT_DOWN()]
-  COMMAND_PHYS_PTT_UP    = 0x55, // [COMMAND_PHYS_PTT_UP()]
   COMMAND_DEBUG_INFO     = 0x01, // [COMMAND_DEBUG_INFO(char[])]
   COMMAND_DEBUG_ERROR    = 0x02, // [COMMAND_DEBUG_ERROR(char[])]
   COMMAND_DEBUG_WARN     = 0x03, // [COMMAND_DEBUG_WARN(char[])]
   COMMAND_DEBUG_DEBUG    = 0x04, // [COMMAND_DEBUG_DEBUG(char[])]
   COMMAND_DEBUG_TRACE    = 0x05, // [COMMAND_DEBUG_TRACE(char[])]
-  COMMAND_HELLO          = 0x06, // [COMMAND_HELLO()]
+  COMMAND_HELLO          = 0x06, // [COMMAND_HELLO(Version)]
   COMMAND_RX_AUDIO       = 0x07, // [COMMAND_RX_AUDIO(int8_t[])]
-  COMMAND_VERSION        = 0x08, // [COMMAND_VERSION(Version)]
   COMMAND_WINDOW_UPDATE  = 0x09,
-  COMMAND_RX_AX25_PACKET = 0x0A, // [COMMAND_RX_AX25_PACKET(uint8_t decoder, uint8_t[])]
+  COMMAND_DEVICE_STATE   = 0x0B, // [COMMAND_DEVICE_STATE(DeviceState)]
 };
 
-// COMMAND_VERSION parameters
+// COMMAND_HELLO parameters
 struct [[gnu::packed]] Version {
   uint16_t     ver;
   char         radioModuleStatus;
@@ -84,14 +72,42 @@ REQUIRE_TRIVIALLY_COPYABLE(Version);
 #define FEATURE_HAS_PHY_PTT (1 << 1)
 #define FEATURE_HAS_ESP32_AFSK (1 << 2)
 
-// COMMAND_SMETER_REPORT parameters
-struct [[gnu::packed]] Rssi {
-  uint8_t     rssi;
-};
-REQUIRE_TRIVIALLY_COPYABLE(Rssi);
+#define HOST_STATE_RADIO_CONFIG_VALID (1 << 0)
+#define HOST_STATE_PTT_REQUESTED      (1 << 1)
+#define HOST_STATE_RX_AUDIO_OPEN      (1 << 2)
+#define HOST_STATE_HIGH_POWER         (1 << 3)
+#define HOST_STATE_RSSI_ENABLED       (1 << 4)
+#define HOST_STATE_FILTER_PRE         (1 << 5)
+#define HOST_STATE_FILTER_HIGH        (1 << 6)
+#define HOST_STATE_FILTER_LOW         (1 << 7)
 
-// COMMAND_HOST_GROUP parameters
-struct [[gnu::packed]] Group {
+#define DEVICE_STATE_RADIO_CONFIG_VALID HOST_STATE_RADIO_CONFIG_VALID
+#define DEVICE_STATE_PTT_REQUESTED      HOST_STATE_PTT_REQUESTED
+#define DEVICE_STATE_RX_AUDIO_OPEN      HOST_STATE_RX_AUDIO_OPEN
+#define DEVICE_STATE_HIGH_POWER         HOST_STATE_HIGH_POWER
+#define DEVICE_STATE_RSSI_ENABLED       HOST_STATE_RSSI_ENABLED
+#define DEVICE_STATE_FILTER_PRE         HOST_STATE_FILTER_PRE
+#define DEVICE_STATE_FILTER_HIGH        HOST_STATE_FILTER_HIGH
+#define DEVICE_STATE_FILTER_LOW         HOST_STATE_FILTER_LOW
+#define DEVICE_STATE_PHYS_PTT_DOWN      (1 << 8)
+#define DEVICE_STATE_TX_ACTIVE          (1 << 9)
+#define DEVICE_STATE_SQUELCHED          (1 << 10)
+
+enum DeviceMode : uint8_t {
+  DEVICE_MODE_TX = 0,
+  DEVICE_MODE_RX = 1,
+  DEVICE_MODE_STOPPED = 2,
+};
+
+enum DeviceStateError : uint8_t {
+  DEVICE_STATE_ERROR_NONE = 0,
+  DEVICE_STATE_ERROR_RADIO_CONFIG_FAILED = 1,
+  DEVICE_STATE_ERROR_FILTERS_FAILED = 2,
+};
+
+struct [[gnu::packed]] HostDesiredState {
+  uint32_t sequence;
+  uint16_t flags;
   uint8_t bw;
   float freq_tx;
   float freq_rx;
@@ -99,41 +115,29 @@ struct [[gnu::packed]] Group {
   uint8_t squelch;
   uint8_t ctcss_rx;
 };
-REQUIRE_TRIVIALLY_COPYABLE(Group);
+REQUIRE_TRIVIALLY_COPYABLE(HostDesiredState);
 
-// COMMAND_HOST_FILTERS parameters
-struct [[gnu::packed]] Filters {
-  uint8_t flags;  // Uses bitmask for pre, high, and low
+struct [[gnu::packed]] DeviceState {
+  uint32_t appliedSequence;
+  uint16_t flags;
+  uint8_t bw;
+  float freq_tx;
+  float freq_rx;
+  uint8_t ctcss_tx;
+  uint8_t squelch;
+  uint8_t ctcss_rx;
+  char radioModuleStatus;
+  uint8_t mode;
+  uint8_t lastError;
+  uint8_t latestRssi;
 };
-REQUIRE_TRIVIALLY_COPYABLE(Filters);
-
-#define FILTER_PRE  (1 << 0)
-#define FILTER_HIGH (1 << 1)
-#define FILTER_LOW  (1 << 2)
-
-// COMMAND_HOST_CONFIG parameters
-struct [[gnu::packed]] Config { 
-  bool isHigh;   
-};
-REQUIRE_TRIVIALLY_COPYABLE(Config);
+REQUIRE_TRIVIALLY_COPYABLE(DeviceState);
 
 // COMMAND_WINDOW_ACK parameters
 struct [[gnu::packed]] WindowUpdate {
   size_t size; 
 };
 REQUIRE_TRIVIALLY_COPYABLE(WindowUpdate);
-
-// COMMAND_HOST_HL parameters
-struct [[gnu::packed]] HlState {
-  bool isHigh; 
-};
-REQUIRE_TRIVIALLY_COPYABLE(HlState);
-
-// COMMAND_HOST_RSSI parameters
-struct [[gnu::packed]] RSSIState {
-  bool on; // true if RSSI is enabled
-};
-REQUIRE_TRIVIALLY_COPYABLE(RSSIState);
 
 class KissBufferedWriter {
 public:
@@ -222,18 +226,7 @@ void sendKv4pVendorFrame(uint8_t kv4pCommand, const uint8_t *payload, size_t len
   sendKissFrame(KISS_CMD_SETHARDWARE, vendorPayload, KV4P_VENDOR_HEADER_LEN + len);
 }
 
-void inline sendHello() {
-  sendKv4pVendorFrame(COMMAND_HELLO, NULL, 0);
-}
-
-void inline sendRssi(uint8_t rssi) {
-  Rssi params = {
-    .rssi = rssi
-  };
-  sendKv4pVendorFrame(COMMAND_SMETER_REPORT, (uint8_t*) &params, sizeof(params));
-}
-
-void inline sendVersion(uint16_t ver, char radioModuleStatus, size_t windowSize, RfModuleType rfModuleType, uint8_t features) {
+void inline sendHello(uint16_t ver, char radioModuleStatus, size_t windowSize, RfModuleType rfModuleType, uint8_t features) {
   Version params = {
     .ver = ver,
     .radioModuleStatus = radioModuleStatus,
@@ -241,11 +234,11 @@ void inline sendVersion(uint16_t ver, char radioModuleStatus, size_t windowSize,
     .rfModuleType = rfModuleType,
     .features = features,
   };
-  sendKv4pVendorFrame(COMMAND_VERSION, (uint8_t*) &params, sizeof(params));
+  sendKv4pVendorFrame(COMMAND_HELLO, (uint8_t*) &params, sizeof(params));
 }
 
-void inline sendPhysPttState(bool isPhysPttDown) {
-  sendKv4pVendorFrame(isPhysPttDown ? COMMAND_PHYS_PTT_DOWN : COMMAND_PHYS_PTT_UP, NULL, 0);
+void inline sendDeviceState(const DeviceState &state) {
+  sendKv4pVendorFrame(COMMAND_DEVICE_STATE, (const uint8_t*) &state, sizeof(state));
 }
 
 void inline sendAudio(const uint8_t *data, size_t len) {
@@ -265,11 +258,12 @@ void inline sendWindowAck(size_t size) {
 }
 
 typedef void (*CommandCallback)(RcvCommand command, uint8_t *params, size_t param_len);
+typedef void (*Ax25Callback)(uint8_t *ax25, size_t ax25_len);
 
 class KissParser {
 public:
-  KissParser(Stream &serial, CommandCallback callback)
-    : _serial(serial), _callback(callback), _frameLen(0), _encodedFrameLen(0),
+  KissParser(Stream &serial, CommandCallback callback, Ax25Callback ax25Callback)
+    : _serial(serial), _callback(callback), _ax25Callback(ax25Callback), _frameLen(0), _encodedFrameLen(0),
       _escape(false), _dropFrame(false), _inFrame(false) {}
 
   void loop() {
@@ -283,6 +277,7 @@ public:
 private:
   Stream &_serial;
   CommandCallback _callback;
+  Ax25Callback _ax25Callback;
   uint8_t _frame[KISS_MAX_FRAME_SIZE];
   size_t _frameLen;
   size_t _encodedFrameLen;
@@ -350,7 +345,7 @@ private:
     }
     if (kissCommand == KISS_CMD_DATA) {
       if (payloadLen > 0 && payloadLen <= PROTO_MTU) {
-        _callback(COMMAND_HOST_TX_AX25, payload, payloadLen);
+        _ax25Callback(payload, payloadLen);
       }
     } else if (kissCommand == KISS_CMD_SETHARDWARE) {
       processVendorFrame(payload, payloadLen);
@@ -383,10 +378,11 @@ private:
 // Forward declaration of handleCommands function
 // This function processes incoming commands, taking a command type, parameters, and their length.
 void handleCommands(RcvCommand command, uint8_t *params, size_t param_len);
+void handleAx25Data(uint8_t *ax25, size_t ax25_len);
 
 // Create a KISS parser and associate it with the existing command handler.
-// DATA frames dispatch as COMMAND_HOST_TX_AX25; KV4P vendor frames dispatch by kv4pCommand.
-KissParser parser(Serial, &handleCommands);
+// DATA frames dispatch as AX.25 bytes; KV4P vendor frames dispatch by kv4pCommand.
+KissParser parser(Serial, &handleCommands, &handleAx25Data);
 
 void inline protocolLoop() {
   parser.loop();

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/protocol.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/protocol.h
@@ -18,13 +18,25 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #pragma once
 
 #include <Arduino.h>
+#include <type_traits>
 #include "globals.h"
-#include "debug.h"
 
-// Delimeter must also match Android app
-const uint8_t COMMAND_DELIMITER[] = {0xDE, 0xAD, 0xBE, 0xEF};
-#define DELIMITER_LENGTH sizeof(COMMAND_DELIMITER)
 #define REQUIRE_TRIVIALLY_COPYABLE(T) static_assert(std::is_trivially_copyable<T>::value, #T " must be trivially copyable!")
+
+// KV4P KISS transport. Standard KISS DATA frames carry AX.25 packets.
+// kv4p-specific commands are carried in KISS SETHARDWARE vendor frames:
+// FEND 0x06 "KV4P" 0x01 <kv4pCommand> <payload...> FEND.
+static constexpr uint8_t KISS_FEND = 0xC0;
+static constexpr uint8_t KISS_FESC = 0xDB;
+static constexpr uint8_t KISS_TFEND = 0xDC;
+static constexpr uint8_t KISS_TFESC = 0xDD;
+static constexpr uint8_t KISS_CMD_DATA = 0x00;
+static constexpr uint8_t KISS_CMD_SETHARDWARE = 0x06;
+static constexpr uint8_t KISS_PORT_0 = 0x00;
+static constexpr uint8_t KV4P_PROTOCOL_VERSION = 0x01;
+static constexpr size_t KV4P_VENDOR_HEADER_LEN = 6; // "KV4P" + version + kv4pCommand
+static constexpr size_t KISS_MAX_FRAME_SIZE = PROTO_MTU + 1 + KV4P_VENDOR_HEADER_LEN;
+static constexpr uint8_t KV4P_VENDOR_PREFIX[] = {'K', 'V', '4', 'P'};
 
 // Incoming commands (Android -> ESP32)
 enum RcvCommand {
@@ -123,41 +135,63 @@ struct [[gnu::packed]] RSSIState {
 };
 REQUIRE_TRIVIALLY_COPYABLE(RSSIState);
 
-/**
- * Send a command with params
- * Format: [DELIMITER(8 bytes)] [CMD(1 byte)] [paramLen(1 byte)] [param data(N bytes)]
- */
-void __sendCmdToHost(SndCommand cmd, const uint8_t *params, size_t paramsLen) {
-  // Safety check: limit paramsLen to 255 for 1-byte length
-  if (paramsLen > PROTO_MTU) {
-    paramsLen = PROTO_MTU;  // or handle differently (split, or error, etc.)
-  }
-  // 1. Leading delimiter
-  Serial.write(COMMAND_DELIMITER, DELIMITER_LENGTH);
-  // 2. Command byte
-  Serial.write((uint8_t*) &cmd, 1);
-  // 3. Parameter length
-  uint16_t len = paramsLen;
-  Serial.write((uint8_t*) &len, sizeof(len));
-  // 4. Parameter bytes
-  if (paramsLen > 0) {
-    Serial.write(params, paramsLen);
+static inline void writeKissEscapedByte(uint8_t b) {
+  if (b == KISS_FEND) {
+    Serial.write(KISS_FESC);
+    Serial.write(KISS_TFEND);
+  } else if (b == KISS_FESC) {
+    Serial.write(KISS_FESC);
+    Serial.write(KISS_TFESC);
+  } else {
+    Serial.write(b);
   }
 }
 
-void inline __sendCmdToHost(SndCommand cmd) {
-  __sendCmdToHost(cmd, NULL, 0);
+void sendKissFrame(uint8_t kissCommand, const uint8_t *payload, size_t len) {
+  Serial.write(KISS_FEND);
+  Serial.write(kissCommand);
+  for (size_t i = 0; i < len; i++) {
+    writeKissEscapedByte(payload[i]);
+  }
+  Serial.write(KISS_FEND);
+}
+
+void inline sendKissDataFrame(const uint8_t *ax25, size_t len) {
+  if (ax25 == NULL) {
+    len = 0;
+  }
+  if (len > PROTO_MTU) {
+    len = PROTO_MTU;
+  }
+  sendKissFrame(KISS_CMD_DATA, ax25, len);
+}
+
+void sendKv4pVendorFrame(uint8_t kv4pCommand, const uint8_t *payload, size_t len) {
+  if (payload == NULL) {
+    len = 0;
+  }
+  if (len > PROTO_MTU) {
+    len = PROTO_MTU;
+  }
+  uint8_t vendorPayload[KV4P_VENDOR_HEADER_LEN + PROTO_MTU];
+  memcpy(vendorPayload, KV4P_VENDOR_PREFIX, sizeof(KV4P_VENDOR_PREFIX));
+  vendorPayload[4] = KV4P_PROTOCOL_VERSION;
+  vendorPayload[5] = kv4pCommand;
+  if (len > 0 && payload != NULL) {
+    memcpy(vendorPayload + KV4P_VENDOR_HEADER_LEN, payload, len);
+  }
+  sendKissFrame(KISS_CMD_SETHARDWARE, vendorPayload, KV4P_VENDOR_HEADER_LEN + len);
 }
 
 void inline sendHello() {
-  __sendCmdToHost(COMMAND_HELLO);
+  sendKv4pVendorFrame(COMMAND_HELLO, NULL, 0);
 }
 
 void inline sendRssi(uint8_t rssi) {
   Rssi params = {
     .rssi = rssi
   };
-  __sendCmdToHost(COMMAND_SMETER_REPORT, (uint8_t*) &params, sizeof(params));
+  sendKv4pVendorFrame(COMMAND_SMETER_REPORT, (uint8_t*) &params, sizeof(params));
 }
 
 void inline sendVersion(uint16_t ver, char radioModuleStatus, size_t windowSize, RfModuleType rfModuleType, uint8_t features) {
@@ -168,43 +202,36 @@ void inline sendVersion(uint16_t ver, char radioModuleStatus, size_t windowSize,
     .rfModuleType = rfModuleType,
     .features = features,
   };
-  __sendCmdToHost(COMMAND_VERSION, (uint8_t*) &params, sizeof(params));
+  sendKv4pVendorFrame(COMMAND_VERSION, (uint8_t*) &params, sizeof(params));
 }
 
 void inline sendPhysPttState(bool isPhysPttDown) {
-  __sendCmdToHost(isPhysPttDown ? COMMAND_PHYS_PTT_DOWN : COMMAND_PHYS_PTT_UP);
+  sendKv4pVendorFrame(isPhysPttDown ? COMMAND_PHYS_PTT_DOWN : COMMAND_PHYS_PTT_UP, NULL, 0);
 }
 
 void inline sendAudio(const uint8_t *data, size_t len) {
-  __sendCmdToHost(COMMAND_RX_AUDIO, data, len);
+  sendKv4pVendorFrame(COMMAND_RX_AUDIO, data, len);
 }
 
 void inline sendAx25Packet(uint8_t decoderId, const uint8_t *data, size_t len) {
-  uint8_t payload[PROTO_MTU];
-  if (len > (PROTO_MTU - 1)) {
-    len = PROTO_MTU - 1;
-  }
-  payload[0] = decoderId;
-  if (len > 0) {
-    memcpy(payload + 1, data, len);
-  }
-  __sendCmdToHost(COMMAND_RX_AX25_PACKET, payload, len + 1);
+  (void)decoderId; // KISS DATA frames are pure AX.25; decoder metadata is intentionally not embedded.
+  sendKissDataFrame(data, len);
 }
 
 void inline sendWindowAck(size_t size) {
   WindowUpdate params = {
     .size = size,
   };
-  __sendCmdToHost(COMMAND_WINDOW_UPDATE, (uint8_t*) &params, sizeof(params));
+  sendKv4pVendorFrame(COMMAND_WINDOW_UPDATE, (uint8_t*) &params, sizeof(params));
 }
 
 typedef void (*CommandCallback)(RcvCommand command, uint8_t *params, size_t param_len);
 
-class FrameParser {
+class KissParser {
 public:
-  FrameParser(Stream &serial, CommandCallback callback) 
-    : _serial(serial), _callback(callback), _matchedDelimiterTokens(0),
-      _command(COMMAND_RCV_UNKNOWN), _commandParamLen(0), _paramIndex(0) {}
+  KissParser(Stream &serial, CommandCallback callback)
+    : _serial(serial), _callback(callback), _frameLen(0), _encodedFrameLen(0),
+      _escape(false), _dropFrame(false), _inFrame(false) {}
 
   void loop() {
     while (_serial.available() > 0) {
@@ -217,52 +244,100 @@ public:
 private:
   Stream &_serial;
   CommandCallback _callback;
-  uint8_t _matchedDelimiterTokens;
-  RcvCommand _command;
-  size_t _commandParamLen; 
-  uint8_t _commandParams[PROTO_MTU];
-  size_t _paramIndex;
+  uint8_t _frame[KISS_MAX_FRAME_SIZE];
+  size_t _frameLen;
+  size_t _encodedFrameLen;
+  bool _escape;
+  bool _dropFrame;
+  bool _inFrame;
 
   inline bool processByte(uint8_t b) {
-    if (_matchedDelimiterTokens < DELIMITER_LENGTH) {
-      _matchedDelimiterTokens = (b == COMMAND_DELIMITER[_matchedDelimiterTokens]) ? _matchedDelimiterTokens + 1 : 0;
-    } else if (_matchedDelimiterTokens == DELIMITER_LENGTH) {
-      _command = (RcvCommand)b;
-      _matchedDelimiterTokens++;
-    } else if (_matchedDelimiterTokens == DELIMITER_LENGTH + 1) {
-      _commandParamLen = b;
-      _matchedDelimiterTokens++;
-    } else if (_matchedDelimiterTokens == DELIMITER_LENGTH + 2) {  
-      _commandParamLen |= (b << 8);
-      _paramIndex = 0;
-      _matchedDelimiterTokens++;
-      if (_commandParamLen == 0) {
-        _callback(_command, _commandParams, 0);
-        sendWindowAck(DELIMITER_LENGTH + 1 + 2);
+    if (b == KISS_FEND) {
+      _encodedFrameLen++;
+      if (_frameLen > 0 && !_dropFrame) {
+        processFrame();
+        sendWindowAck(_encodedFrameLen);
         resetParser();
+        _inFrame = true;
+        _encodedFrameLen = 1;
         return true;
       }
-      if (_commandParamLen > PROTO_MTU) {
-        resetParser();
+      resetParser();
+      _inFrame = true;
+      _encodedFrameLen = 1;
+    } else if (!_inFrame) {
+      return false;
+    } else if (_dropFrame) {
+      _encodedFrameLen++;
+      return false;
+    } else if (_escape) {
+      _encodedFrameLen++;
+      if (b == KISS_TFEND) {
+        appendByte(KISS_FEND);
+      } else if (b == KISS_TFESC) {
+        appendByte(KISS_FESC);
+      } else {
+        // Unknown KISS escape: drop this frame and wait for the next FEND.
+        _dropFrame = true;
       }
+      _escape = false;
+    } else if (b == KISS_FESC) {
+      _encodedFrameLen++;
+      _escape = true;
     } else {
-      if (_paramIndex < _commandParamLen) {
-        _commandParams[_paramIndex++] = b;
-      }
-      if (_paramIndex == _commandParamLen) {
-        _callback(_command, _commandParams, _commandParamLen);
-        sendWindowAck(DELIMITER_LENGTH + 1 + 2 + _commandParamLen);
-        resetParser();
-        return true;
-      }
+      _encodedFrameLen++;
+      appendByte(b);
     }
     return false;
   }
 
+  void appendByte(uint8_t b) {
+    if (_frameLen >= KISS_MAX_FRAME_SIZE) {
+      _dropFrame = true;
+      return;
+    }
+    _frame[_frameLen++] = b;
+  }
+
+  void processFrame() {
+    uint8_t kissCommandByte = _frame[0];
+    uint8_t kissPort = kissCommandByte >> 4;
+    uint8_t kissCommand = kissCommandByte & 0x0F;
+    uint8_t *payload = _frame + 1;
+    size_t payloadLen = _frameLen - 1;
+
+    if (kissPort != KISS_PORT_0) {
+      return;
+    }
+    if (kissCommand == KISS_CMD_DATA) {
+      if (payloadLen > 0 && payloadLen <= PROTO_MTU) {
+        _callback(COMMAND_HOST_TX_AX25, payload, payloadLen);
+      }
+    } else if (kissCommand == KISS_CMD_SETHARDWARE) {
+      processVendorFrame(payload, payloadLen);
+    }
+  }
+
+  void processVendorFrame(uint8_t *payload, size_t payloadLen) {
+    if (payloadLen < KV4P_VENDOR_HEADER_LEN) {
+      return;
+    }
+    if (memcmp(payload, KV4P_VENDOR_PREFIX, sizeof(KV4P_VENDOR_PREFIX)) != 0) {
+      return;
+    }
+    if (payload[4] != KV4P_PROTOCOL_VERSION) {
+      return;
+    }
+    RcvCommand command = (RcvCommand)payload[5];
+    _callback(command, payload + KV4P_VENDOR_HEADER_LEN, payloadLen - KV4P_VENDOR_HEADER_LEN);
+  }
+
   void resetParser() {
-    _matchedDelimiterTokens = 0;
-    _paramIndex = 0;
-    _commandParamLen = 0;
+    _frameLen = 0;
+    _encodedFrameLen = 0;
+    _escape = false;
+    _dropFrame = false;
+    _inFrame = false;
   }
 };
 
@@ -270,9 +345,9 @@ private:
 // This function processes incoming commands, taking a command type, parameters, and their length.
 void handleCommands(RcvCommand command, uint8_t *params, size_t param_len);
 
-// Create an instance of FrameParser and associate it with the handleCommands function
-// The FrameParser object uses the Serial interface and the handleCommands function for processing commands.
-FrameParser parser(Serial, &handleCommands);
+// Create a KISS parser and associate it with the existing command handler.
+// DATA frames dispatch as COMMAND_HOST_TX_AX25; KV4P vendor frames dispatch by kv4pCommand.
+KissParser parser(Serial, &handleCommands);
 
 void inline protocolLoop() {
   parser.loop();

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/protocol.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/protocol.h
@@ -135,25 +135,64 @@ struct [[gnu::packed]] RSSIState {
 };
 REQUIRE_TRIVIALLY_COPYABLE(RSSIState);
 
-static inline void writeKissEscapedByte(uint8_t b) {
-  if (b == KISS_FEND) {
-    Serial.write(KISS_FESC);
-    Serial.write(KISS_TFEND);
-  } else if (b == KISS_FESC) {
-    Serial.write(KISS_FESC);
-    Serial.write(KISS_TFESC);
-  } else {
-    Serial.write(b);
+class KissBufferedWriter {
+public:
+  explicit KissBufferedWriter(Stream &out) : _out(out), _used(0) {}
+
+  void begin(uint8_t command) {
+    put(KISS_FEND);
+    put(command);
   }
-}
+
+  void writeEscaped(uint8_t b) {
+    if (b == KISS_FEND) {
+      put(KISS_FESC);
+      put(KISS_TFEND);
+    } else if (b == KISS_FESC) {
+      put(KISS_FESC);
+      put(KISS_TFESC);
+    } else {
+      put(b);
+    }
+  }
+
+  void end() {
+    put(KISS_FEND);
+    flush();
+  }
+
+private:
+  static constexpr size_t BUF_SIZE = 64;
+
+  Stream &_out;
+  uint8_t _buf[BUF_SIZE];
+  size_t _used;
+
+  void put(uint8_t b) {
+    if (_used == BUF_SIZE) {
+      flush();
+    }
+    _buf[_used++] = b;
+  }
+
+  void flush() {
+    if (_used > 0) {
+      _out.write(_buf, _used);
+      _used = 0;
+    }
+  }
+};
 
 void sendKissFrame(uint8_t kissCommand, const uint8_t *payload, size_t len) {
-  Serial.write(KISS_FEND);
-  Serial.write(kissCommand);
-  for (size_t i = 0; i < len; i++) {
-    writeKissEscapedByte(payload[i]);
+  if (len > (PROTO_MTU + KV4P_VENDOR_HEADER_LEN)) {
+    len = PROTO_MTU + KV4P_VENDOR_HEADER_LEN;
   }
-  Serial.write(KISS_FEND);
+  KissBufferedWriter writer(Serial);
+  writer.begin(kissCommand);
+  for (size_t i = 0; i < len; i++) {
+    writer.writeEscaped(payload[i]);
+  }
+  writer.end();
 }
 
 void inline sendKissDataFrame(const uint8_t *ax25, size_t len) {

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/readme.md
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/readme.md
@@ -104,6 +104,8 @@ struct version {
   char         radioModuleStatus; // 1 byte
   size_t       windowSize;        // 4 bytes
   uint32_t     rfModuleType;      // 4 bytes (enum)
+  float        minRadioFreq;      // 4 bytes
+  float        maxRadioFreq;      // 4 bytes
   uint8_t      features;          // 1 byte (bitmask)
 } __attribute__((__packed__));
 typedef struct version Version;
@@ -120,13 +122,14 @@ struct hello {
 typedef struct hello Hello;
 ```
 
-Firmware sends `COMMAND_HELLO(Hello)` after boot-time radio initialization. Android validates the version/status fields and seeds its initial radio-module state from the appended `DeviceState`.
+Firmware sends `COMMAND_HELLO(Hello)` after boot-time radio initialization. Android validates the version/status fields, adopts `minRadioFreq`/`maxRadioFreq` as the module's usable RX range, and seeds its initial radio-module state from the appended `DeviceState`.
 
 ### `COMMAND_HOST_DESIRED_STATE` Parameters
 
 ```c
 struct host_desired_state {
   uint32_t sequence;
+  int32_t  memoryId; // -1 means VFO/no memory
   uint16_t flags;
   uint8_t  bw;
   float    freq_tx;
@@ -154,6 +157,7 @@ Android sends the full desired-state snapshot whenever one field changes. Firmwa
 ```c
 struct device_state {
   uint32_t appliedSequence;
+  int32_t  memoryId; // -1 means VFO/no memory
   uint16_t flags;
   uint8_t  bw;
   float    freq_tx;
@@ -175,7 +179,7 @@ typedef struct device_state DeviceState;
 
 Firmware sends `COMMAND_DEVICE_STATE` immediately after applying desired state, immediately when `latestRssi` changes, and periodically every 500 ms as a heartbeat/state refresh. RSSI/S-meter data is reported through `latestRssi`; there is no separate S-meter report command.
 
-Firmware persists stable radio settings in NVS and restores them on startup before sending `COMMAND_HELLO`: bandwidth, TX/RX frequencies, TX/RX tones, squelch level, high-power preference, RSSI preference, and filter flags. Transient state is not restored: sequence, PTT requested, and RX audio open always start clear.
+Firmware persists stable radio settings in NVS and restores them on startup before sending `COMMAND_HELLO`: memory id, bandwidth, TX/RX frequencies, TX/RX tones, squelch level, high-power preference, RSSI preference, and filter flags. If persisted TX/RX frequencies are outside the configured RF module's range, firmware clamps them into range and clears `memoryId` to `-1` before applying radio config. Transient state is not restored: sequence, PTT requested, and RX audio open always start clear.
 
 ### `COMMAND_WINDOW_UPDATE` Parameters **(ESP32 → Android)**
 

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/readme.md
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/readme.md
@@ -16,8 +16,7 @@ The KV4P-HT protocol defines the communication interface between the microcontro
   * Firmware replies with `COMMAND_DEVICE_STATE` snapshots describing applied state.
   * Legacy one-shot control commands were removed.
  
-* 2.1
-* **Changelog:**
+* **Historical 2.1 changelog:**
   * Initial version with core command set.
   * Parameter length field upgraded from 1 byte to 2 bytes (`uint16_t`).
   * Added `COMMAND_WINDOW_UPDATE` **(ESP32 → Android)**.
@@ -60,15 +59,28 @@ Inside KISS frame payloads, bytes are escaped as follows:
 
 All other bytes are written unchanged. The old `0xDEADBEEF` delimiter and top-level `uint16` length field are no longer present on the wire.
 
-## Incoming Commands (Android → ESP32)
+## Incoming KISS Frame Types (Android → ESP32)
+
+| KISS Command | Name                   | Description                       |
+| ------------ | ---------------------- | --------------------------------- |
+| `0x00`       | KISS DATA frame        | Transmit AX.25 packet bytes       |
+| `0x06`       | KISS SETHARDWARE frame | Carry a kv4p vendor command frame |
+
+## Incoming KV4P Vendor Commands (Android → ESP32)
 
 | Command Code | Name                    | Description                                                    |
 | ------------ | ----------------------- | -------------------------------------------------------------- |
 | `0x07`       | `COMMAND_HOST_TX_AUDIO` | Receive Tx OPUS audio data (payload required, flow-controlled) |
-| `0x0A`       | KISS DATA frame         | Transmit AX.25 packet bytes                                    |
 | `0x0D`       | `COMMAND_HOST_DESIRED_STATE` | Desired radio/control state snapshot                     |
 
-## Outgoing Commands (ESP32 → Android)
+## Outgoing KISS Frame Types (ESP32 → Android)
+
+| KISS Command | Name                   | Description                         |
+| ------------ | ---------------------- | ----------------------------------- |
+| `0x00`       | KISS DATA frame        | Received AX.25 packet bytes         |
+| `0x06`       | KISS SETHARDWARE frame | Carry a kv4p vendor command frame   |
+
+## Outgoing KV4P Vendor Commands (ESP32 → Android)
 
 | Command Code | Name                    | Description                                 |
 | ------------ | ----------------------- | ------------------------------------------- |
@@ -207,10 +219,10 @@ A window-based flow control mechanism, inspired by HTTP/2, is used to regulate t
 
 ## Command Handling Strategy
 
-* Most commands follow a **fire-and-forget** approach.
-* Some commands may trigger a reply (indicated in comments).
-* There are no explicit response types; responses are sent as separate commands.
-* All ESP32 incoming commands are subject to **window-based flow control**.
+* Android sends complete `COMMAND_HOST_DESIRED_STATE` snapshots instead of separate one-shot control commands.
+* Firmware reports the applied runtime state through `COMMAND_DEVICE_STATE` snapshots.
+* KISS DATA frames carry AX.25 packets directly, outside the kv4p vendor command namespace.
+* Android-to-firmware vendor commands are subject to **window-based flow control**.
 
 ## Byte Order and Bit Significance
 

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/readme.md
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/readme.md
@@ -14,6 +14,8 @@ The KV4P-HT protocol defines the communication interface between the microcontro
   * `COMMAND_HELLO` now carries the version/status payload after firmware radio initialization completes.
   * Android now sends `COMMAND_HOST_DESIRED_STATE` snapshots for radio config, filters, PTT, audio-open, high-power, and RSSI state.
   * Firmware replies with `COMMAND_DEVICE_STATE` snapshots describing applied state.
+  * Firmware coalesces state changes through a dirty flag; `deviceStateLoop()` is the single state-report sender.
+  * Android retries an unacknowledged desired-state snapshot by resending the same sequence.
   * Legacy one-shot control commands were removed.
  
 * **Historical 2.1 changelog:**
@@ -150,7 +152,9 @@ typedef struct host_desired_state HostDesiredState;
 #define HOST_STATE_FILTER_LOW         (1 << 7)
 ```
 
-Android sends the full desired-state snapshot whenever one field changes. Firmware applies changed radio/filter/control fields, derives its mode, and reports the result with `COMMAND_DEVICE_STATE`.
+Android sends the full desired-state snapshot whenever one field changes. Firmware applies changed radio/filter/control fields, derives its mode, and marks device state dirty so `deviceStateLoop()` can report the result with `COMMAND_DEVICE_STATE`.
+
+Android treats `DeviceState.appliedSequence` as the acknowledgement for the latest desired-state snapshot. If received device state does not match the last sent desired snapshot, Android may retry the exact same `HostDesiredState` with the same `sequence`. Retries are bounded; they are not new logical state changes and must not increment `sequence`.
 
 ### `COMMAND_DEVICE_STATE` Parameters
 
@@ -177,7 +181,9 @@ typedef struct device_state DeviceState;
 #define DEVICE_STATE_SQUELCHED     (1 << 10)
 ```
 
-Firmware sends `COMMAND_DEVICE_STATE` immediately after applying desired state, immediately when `latestRssi` changes, and periodically every 500 ms as a heartbeat/state refresh. RSSI/S-meter data is reported through `latestRssi`; there is no separate S-meter report command.
+Firmware sends `COMMAND_DEVICE_STATE` from `deviceStateLoop()`. State producers such as desired-state reconciliation, RSSI changes, squelch changes, and physical PTT changes set a dirty flag instead of writing serial frames directly. The next loop pass flushes dirty state, so change reports are effectively immediate but still async and coalesced through one sender. Firmware also sends `COMMAND_DEVICE_STATE` every 500 ms as a heartbeat/state refresh. RSSI/S-meter data is reported through `latestRssi`; there is no separate S-meter report command.
+
+Scanning remains Android-owned because Android owns the memory list, memory groups, skip-during-scan flags, offsets, and UI selection. Firmware reports the current squelch state with `DEVICE_STATE_SQUELCHED`; Android uses that received state to decide when to advance to the next memory.
 
 Firmware persists stable radio settings in NVS and restores them on startup before sending `COMMAND_HELLO`: memory id, bandwidth, TX/RX frequencies, TX/RX tones, squelch level, high-power preference, RSSI preference, and filter flags. If persisted TX/RX frequencies are outside the configured RF module's range, firmware clamps them into range and clears `memoryId` to `-1` before applying radio config. Transient state is not restored: sequence, PTT requested, and RX audio open always start clear.
 
@@ -225,6 +231,8 @@ A window-based flow control mechanism, inspired by HTTP/2, is used to regulate t
 
 * Android sends complete `COMMAND_HOST_DESIRED_STATE` snapshots instead of separate one-shot control commands.
 * Firmware reports the applied runtime state through `COMMAND_DEVICE_STATE` snapshots.
+* Firmware state producers mark device state dirty; only `deviceStateLoop()` sends `COMMAND_DEVICE_STATE`.
+* Android compares desired and device state. If the device does not acknowledge the latest desired snapshot, Android may resend the same snapshot/sequence a small number of times.
 * KISS DATA frames carry AX.25 packets directly, outside the kv4p vendor command namespace.
 * Android-to-firmware vendor commands are subject to **window-based flow control**.
 

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/readme.md
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/readme.md
@@ -8,6 +8,9 @@ The KV4P-HT protocol defines the communication interface between the microcontro
 
 * **Current Version:** 2.2
 * **Changelog:**
+  * Serial transport now uses KV4P KISS framing. The old `0xDEADBEEF` delimiter and top-level length field are removed.
+  * Standard KISS DATA frames carry AX.25 packets directly.
+  * kv4p-specific commands are carried in KISS SETHARDWARE vendor frames with payload prefix `"KV4P"` and protocol version `1`.
   * Incoming command set now includes COMMAND_HOST_HL (0x08) and COMMAND_HOST_RSSI (0x09).
   * COMMAND_HOST_CONFIG params are bool isHigh (not radioType).
   * COMMAND_VERSION payload includes windowSize, rfModuleType, and features (not hw_ver_t).
@@ -23,14 +26,38 @@ The KV4P-HT protocol defines the communication interface between the microcontro
 
 ## Packet Structure
 
-Each message consists of the following fields:
+Serial messages use KV4P KISS transport.
 
-| Field             | Size (bytes) | Description                                      |
-| ----------------- | ------------ | ------------------------------------------------ |
-| Command Delimiter | 4            | Fixed value (`0xDEADBEEF`)                       |
-| Command           | 1            | Identifies the request or response               |
-| Parameter Length  | 2            | Length of the following parameters (0-65535, LE) |
-| Parameters        | 0-2048       | Command-specific data                            |
+### AX.25 KISS DATA Frames
+
+AX.25 packets are sent as standard KISS DATA frames:
+
+```
+FEND 0x00 <escaped AX.25 frame bytes> FEND
+```
+
+The AX.25 payload does not include a kv4p command byte, decoder ID, or top-level length field.
+
+### KV4P Vendor Frames
+
+Non-AX.25 kv4p commands are sent as KISS SETHARDWARE vendor frames:
+
+```
+FEND 0x06 "KV4P" 0x01 <kv4pCommand> <escaped command payload bytes> FEND
+```
+
+The payload prefix is ASCII `"KV4P"`, followed by `uint8 protocolVersion = 1`, the existing kv4p command byte, and the existing command payload bytes.
+
+### Escaping
+
+Inside KISS frame payloads, bytes are escaped as follows:
+
+| Byte | Encoded as |
+| ---- | ---------- |
+| `0xC0` | `0xDB 0xDC` |
+| `0xDB` | `0xDB 0xDD` |
+
+All other bytes are written unchanged. The old `0xDEADBEEF` delimiter and top-level `uint16` length field are no longer present on the wire.
 
 ## Incoming Commands (Android → ESP32)
 
@@ -202,20 +229,21 @@ A window-based flow control mechanism, inspired by HTTP/2, is used to regulate t
 ### Push-to-talk activation
 
 ```
-[ 0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x00, 0x00 ]
+[ 0xC0, 0x06, 'K', 'V', '4', 'P', 0x01, 0x01, 0xC0 ]
 ```
 
-* `0xDEADBEEF`: Command Delimiter
+* `0xC0`: KISS FEND
+* `0x06`: KISS SETHARDWARE
+* `"KV4P" 0x01`: KV4P vendor prefix and protocol version
 * `0x01`: `COMMAND_HOST_PTT_DOWN`
-* `0x00 0x00`: Parameter Length (no parameters)
 
 ### Example Debug Message
 
 ```
-[ 0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x05, 0x00, 'E', 'r', 'r', 'o', 'r' ]
+[ 0xC0, 0x06, 'K', 'V', '4', 'P', 0x01, 0x01, 'E', 'r', 'r', 'o', 'r', 0xC0 ]
 ```
 
-* `0xDEADBEEF`: Command Delimiter
+* `0x06`: KISS SETHARDWARE
+* `"KV4P" 0x01`: KV4P vendor prefix and protocol version
 * `0x01`: `COMMAND_DEBUG_INFO`
-* `0x05 0x00`: Parameter Length (5 bytes)
 * `'Error'`: Debug message content

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/readme.md
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/readme.md
@@ -77,7 +77,7 @@ All other bytes are written unchanged. The old `0xDEADBEEF` delimiter and top-le
 | `0x03`       | `COMMAND_DEBUG_WARN`    | Sends debug warning message                 |
 | `0x04`       | `COMMAND_DEBUG_DEBUG`   | Sends debug debug-level message             |
 | `0x05`       | `COMMAND_DEBUG_TRACE`   | Sends debug trace message                   |
-| `0x06`       | `COMMAND_HELLO`         | Hello handshake message with version/status |
+| `0x06`       | `COMMAND_HELLO`         | Hello handshake message with version/status and initial device state |
 | `0x07`       | `COMMAND_RX_AUDIO`      | Sends Rx OPUS audio data (payload required) |
 | `0x09`       | `COMMAND_WINDOW_UPDATE` | Updates available receive window            |
 | `0x0B`       | `COMMAND_DEVICE_STATE`  | Applied radio/control state snapshot         |
@@ -100,9 +100,15 @@ typedef struct version Version;
 #define FEATURE_HAS_HL      (1 << 0)
 #define FEATURE_HAS_PHY_PTT (1 << 1)
 #define FEATURE_HAS_ESP32_AFSK (1 << 2)
+
+struct hello {
+  Version     version;
+  DeviceState deviceState;
+} __attribute__((__packed__));
+typedef struct hello Hello;
 ```
 
-Firmware sends `COMMAND_HELLO(Version)` after boot-time radio initialization. Android validates this payload directly.
+Firmware sends `COMMAND_HELLO(Hello)` after boot-time radio initialization. Android validates the version/status fields and seeds its initial radio-module state from the appended `DeviceState`.
 
 ### `COMMAND_HOST_DESIRED_STATE` Parameters
 
@@ -156,6 +162,8 @@ typedef struct device_state DeviceState;
 ```
 
 Firmware sends `COMMAND_DEVICE_STATE` immediately after applying desired state, immediately when `latestRssi` changes, and periodically every 500 ms as a heartbeat/state refresh. RSSI/S-meter data is reported through `latestRssi`; there is no separate S-meter report command.
+
+Firmware persists stable radio settings in NVS and restores them on startup before sending `COMMAND_HELLO`: bandwidth, TX/RX frequencies, TX/RX tones, squelch level, high-power preference, RSSI preference, and filter flags. Transient state is not restored: sequence, PTT requested, and RX audio open always start clear.
 
 ### `COMMAND_WINDOW_UPDATE` Parameters **(ESP32 → Android)**
 

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/readme.md
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/readme.md
@@ -11,16 +11,17 @@ The KV4P-HT protocol defines the communication interface between the microcontro
   * Serial transport now uses KV4P KISS framing. The old `0xDEADBEEF` delimiter and top-level length field are removed.
   * Standard KISS DATA frames carry AX.25 packets directly.
   * kv4p-specific commands are carried in KISS SETHARDWARE vendor frames with payload prefix `"KV4P"` and protocol version `1`.
-  * Incoming command set now includes COMMAND_HOST_HL (0x08) and COMMAND_HOST_RSSI (0x09).
-  * COMMAND_HOST_CONFIG params are bool isHigh (not radioType).
-  * COMMAND_VERSION payload includes windowSize, rfModuleType, and features (not hw_ver_t).
+  * `COMMAND_HELLO` now carries the version/status payload after firmware radio initialization completes.
+  * Android now sends `COMMAND_HOST_DESIRED_STATE` snapshots for radio config, filters, PTT, audio-open, high-power, and RSSI state.
+  * Firmware replies with `COMMAND_DEVICE_STATE` snapshots describing applied state.
+  * Legacy one-shot control commands were removed.
  
 * 2.1
 * **Changelog:**
   * Initial version with core command set.
   * Parameter length field upgraded from 1 byte to 2 bytes (`uint16_t`).
   * Added `COMMAND_WINDOW_UPDATE` **(ESP32 → Android)**.
-  * `COMMAND_VERSION` payload now includes `windowSize`, **`rfModuleType`**, and **`features`**.
+  * Version/status payload includes `windowSize`, **`rfModuleType`**, and **`features`**.
   * Audio streams are now OPUS encoded.
   * Window-based flow control implemented for all incoming commands, inspired by HTTP/2.
 
@@ -63,43 +64,34 @@ All other bytes are written unchanged. The old `0xDEADBEEF` delimiter and top-le
 
 | Command Code | Name                    | Description                                                    |
 | ------------ | ----------------------- | -------------------------------------------------------------- |
-| `0x01`       | `COMMAND_HOST_PTT_DOWN` | Push-to-talk activation                                        |
-| `0x02`       | `COMMAND_HOST_PTT_UP`   | Push-to-talk deactivation                                      |
-| `0x03`       | `COMMAND_HOST_GROUP`    | Set group (parameters required)                                |
-| `0x04`       | `COMMAND_HOST_FILTERS`  | Set filters (parameters required)                              |
-| `0x05`       | `COMMAND_HOST_STOP`     | Stop current operation                                         |
-| `0x06`       | `COMMAND_HOST_CONFIG`   | Configure device (may return version)                          |
 | `0x07`       | `COMMAND_HOST_TX_AUDIO` | Receive Tx OPUS audio data (payload required, flow-controlled) |
-| `0x08`       | `COMMAND_HOST_HL`       | Set High/Low state (parameters required)                       |
-| `0x09`       | `COMMAND_HOST_RSSI`     | Enable/disable RSSI reports (parameters required)              |
+| `0x0A`       | KISS DATA frame         | Transmit AX.25 packet bytes                                    |
+| `0x0D`       | `COMMAND_HOST_DESIRED_STATE` | Desired radio/control state snapshot                     |
 
 ## Outgoing Commands (ESP32 → Android)
 
 | Command Code | Name                    | Description                                 |
 | ------------ | ----------------------- | ------------------------------------------- |
-| `0x53`       | `COMMAND_SMETER_REPORT` | Reports RSSI level                          |
-| `0x44`       | `COMMAND_PHYS_PTT_DOWN` | Physical push-to-talk activation            |
-| `0x55`       | `COMMAND_PHYS_PTT_UP`   | Physical push-to-talk deactivation          |
 | `0x01`       | `COMMAND_DEBUG_INFO`    | Sends debug info message                    |
 | `0x02`       | `COMMAND_DEBUG_ERROR`   | Sends debug error message                   |
 | `0x03`       | `COMMAND_DEBUG_WARN`    | Sends debug warning message                 |
 | `0x04`       | `COMMAND_DEBUG_DEBUG`   | Sends debug debug-level message             |
 | `0x05`       | `COMMAND_DEBUG_TRACE`   | Sends debug trace message                   |
-| `0x06`       | `COMMAND_HELLO`         | Hello handshake message                     |
+| `0x06`       | `COMMAND_HELLO`         | Hello handshake message with version/status |
 | `0x07`       | `COMMAND_RX_AUDIO`      | Sends Rx OPUS audio data (payload required) |
-| `0x08`       | `COMMAND_VERSION`       | Sends firmware version information          |
 | `0x09`       | `COMMAND_WINDOW_UPDATE` | Updates available receive window            |
+| `0x0B`       | `COMMAND_DEVICE_STATE`  | Applied radio/control state snapshot         |
 
 ## Command Parameters
 
-### `COMMAND_VERSION` Parameters
+### `COMMAND_HELLO` Parameters
 
 ```c
 struct version {
   uint16_t     ver;               // 2 bytes
   char         radioModuleStatus; // 1 byte
   size_t       windowSize;        // 4 bytes
-  uint8_t      rfModuleType;      // 1 byte (enum)
+  uint32_t     rfModuleType;      // 4 bytes (enum)
   uint8_t      features;          // 1 byte (bitmask)
 } __attribute__((__packed__));
 typedef struct version Version;
@@ -107,70 +99,63 @@ typedef struct version Version;
 // features bitmask
 #define FEATURE_HAS_HL      (1 << 0)
 #define FEATURE_HAS_PHY_PTT (1 << 1)
+#define FEATURE_HAS_ESP32_AFSK (1 << 2)
 ```
 
-### `COMMAND_SMETER_REPORT` Parameters
+Firmware sends `COMMAND_HELLO(Version)` after boot-time radio initialization. Android validates this payload directly.
+
+### `COMMAND_HOST_DESIRED_STATE` Parameters
 
 ```c
-struct rssi {
-  uint8_t     rssi; // 1 byte
+struct host_desired_state {
+  uint32_t sequence;
+  uint16_t flags;
+  uint8_t  bw;
+  float    freq_tx;
+  float    freq_rx;
+  uint8_t  ctcss_tx;
+  uint8_t  squelch;
+  uint8_t  ctcss_rx;
 } __attribute__((__packed__));
-typedef struct rssi Rssi;
+typedef struct host_desired_state HostDesiredState;
+
+#define HOST_STATE_RADIO_CONFIG_VALID (1 << 0)
+#define HOST_STATE_PTT_REQUESTED      (1 << 1)
+#define HOST_STATE_RX_AUDIO_OPEN      (1 << 2)
+#define HOST_STATE_HIGH_POWER         (1 << 3)
+#define HOST_STATE_RSSI_ENABLED       (1 << 4)
+#define HOST_STATE_FILTER_PRE         (1 << 5)
+#define HOST_STATE_FILTER_HIGH        (1 << 6)
+#define HOST_STATE_FILTER_LOW         (1 << 7)
 ```
 
-### `COMMAND_HOST_GROUP` Parameters
+Android sends the full desired-state snapshot whenever one field changes. Firmware applies changed radio/filter/control fields, derives its mode, and reports the result with `COMMAND_DEVICE_STATE`.
+
+### `COMMAND_DEVICE_STATE` Parameters
 
 ```c
-struct group {
-  uint8_t bw;       // 1 byte
-  float   freq_tx;  // 4 bytes
-  float   freq_rx;  // 4 bytes
-  uint8_t ctcss_tx; // 1 byte
-  uint8_t squelch;  // 1 byte
-  uint8_t ctcss_rx; // 1 byte
+struct device_state {
+  uint32_t appliedSequence;
+  uint16_t flags;
+  uint8_t  bw;
+  float    freq_tx;
+  float    freq_rx;
+  uint8_t  ctcss_tx;
+  uint8_t  squelch;
+  uint8_t  ctcss_rx;
+  char     radioModuleStatus;
+  uint8_t  mode;
+  uint8_t  lastError;
+  uint8_t  latestRssi;
 } __attribute__((__packed__));
-typedef struct group Group;
+typedef struct device_state DeviceState;
+
+#define DEVICE_STATE_PHYS_PTT_DOWN (1 << 8)
+#define DEVICE_STATE_TX_ACTIVE     (1 << 9)
+#define DEVICE_STATE_SQUELCHED     (1 << 10)
 ```
 
-### `COMMAND_HOST_FILTERS` Parameters
-
-```c
-struct filters {
-  uint8_t flags;  // 1 byte - Uses bitmask for pre, high, and low
-} __attribute__((__packed__));
-typedef struct filters Filters;
-
-#define FILTER_PRE  (1 << 0) // Bit 0
-#define FILTER_HIGH (1 << 1) // Bit 1
-#define FILTER_LOW  (1 << 2) // Bit 2
-```
-
-### `COMMAND_HOST_CONFIG` Parameters
-
-```c
-struct config {
-  bool isHigh; // 1 byte
-} __attribute__((__packed__));
-typedef struct config Config;
-```
-
-### `COMMAND_HOST_HL` Parameters
-
-```c
-struct hl_state {
-  bool isHigh; // 1 byte
-} __attribute__((__packed__));
-typedef struct hl_state HlState;
-```
-
-### `COMMAND_HOST_RSSI` Parameters
-
-```c
-struct rssi_state {
-  bool on; // 1 byte, true = enable periodic RSSI reports
-} __attribute__((__packed__));
-typedef struct rssi_state RSSIState;
-```
+Firmware sends `COMMAND_DEVICE_STATE` immediately after applying desired state, immediately when `latestRssi` changes, and periodically every 500 ms as a heartbeat/state refresh. RSSI/S-meter data is reported through `latestRssi`; there is no separate S-meter report command.
 
 ### `COMMAND_WINDOW_UPDATE` Parameters **(ESP32 → Android)**
 
@@ -187,7 +172,7 @@ A window-based flow control mechanism, inspired by HTTP/2, is used to regulate t
 
 1. **Window Size Declaration**:
 
-   * The ESP32 sends a "desired" initial window size in the `COMMAND_VERSION` payload.
+   * The ESP32 sends a "desired" initial window size in the `COMMAND_HELLO` payload.
    * This typically matches the size of its internal USB receive buffer.
 
 2. **Window Consumption**:
@@ -226,16 +211,16 @@ A window-based flow control mechanism, inspired by HTTP/2, is used to regulate t
 
 ## Example Packets
 
-### Push-to-talk activation
+### Desired-state update
 
 ```
-[ 0xC0, 0x06, 'K', 'V', '4', 'P', 0x01, 0x01, 0xC0 ]
+[ 0xC0, 0x06, 'K', 'V', '4', 'P', 0x01, 0x0D, ...state bytes..., 0xC0 ]
 ```
 
 * `0xC0`: KISS FEND
 * `0x06`: KISS SETHARDWARE
 * `"KV4P" 0x01`: KV4P vendor prefix and protocol version
-* `0x01`: `COMMAND_HOST_PTT_DOWN`
+* `0x0D`: `COMMAND_HOST_DESIRED_STATE`
 
 ### Example Debug Message
 

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/rxAudio.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/rxAudio.h
@@ -70,7 +70,7 @@ private:
 static void onAfskPacketDecoded(const uint8_t *frame, size_t len) {
   if (frame && len > 0) {
     // Decoder ID 0 = ESP32 demodulator path.
-    sendAx25Packet(0, frame, len);
+    sendAx25Packet(frame, len);
   }
 }
 

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/rxAudio.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/rxAudio.h
@@ -35,7 +35,9 @@ public:
       if (len > PROTO_MTU) {
         len = PROTO_MTU;
       }
-      sendAudio((uint8_t*)data, len);
+      if (mode == MODE_RX) {
+        sendAudio((uint8_t*)data, len);
+      }
       return len;
     }
     return len;
@@ -128,6 +130,9 @@ inline void setUpADCAttenuator() {
 }
 
 void initI2SRx() {
+  if (rxStreamConfigured) {
+    return;
+  }
   injectADCBias();
   setUpADCAttenuator();
   //AudioToolsLogger.begin(debugPrinter, AudioToolsLogLevel::Debug);
@@ -171,7 +176,7 @@ void endI2SRx() {
 }
   
 void rxAudioLoop() {
-  if (mode == MODE_RX) {
+  if (mode == MODE_RX || mode == MODE_STOPPED) {
     mute.setActive(squelched);
     rxCopier.copy();
     esp_task_wdt_reset();

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/txAudio.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/txAudio.h
@@ -110,7 +110,7 @@ void inline txAudioLoop() {
   if (mode == MODE_TX) {
     // Check for runaway tx
     if ((millis() - txStartTime) > RUNAWAY_TX_SEC * 1000) {
-      setMode(MODE_RX);
+      setMode(rxIdleMode());
       esp_task_wdt_reset();
     }
   }

--- a/microcontroller-src/platformio.ini
+++ b/microcontroller-src/platformio.ini
@@ -10,12 +10,14 @@
 
 [platformio]
 src_dir = kv4p_ht_esp32_wroom_32
+default_envs = esp32dev, esp32dev-release
 
 [env:esp32dev]
 platform = espressif32 @ 6.10.0
 board = esp32dev
 framework = arduino
 monitor_speed = 115200
+test_build_src = no
 build_flags =
   -DARDUINO_RUNNING_CORE=1
   -DARDUINO_EVENT_RUNNING_CORE=0
@@ -32,3 +34,12 @@ build_flags =
   -DARDUINO_RUNNING_CORE=1
   -DARDUINO_EVENT_RUNNING_CORE=0
   -DRELEASE=1
+
+[env:esp32dev-test]
+platform = espressif32 @ 6.10.0
+board = esp32dev
+framework = arduino
+test_build_src = no
+build_flags =
+  -DARDUINO_RUNNING_CORE=1
+  -DARDUINO_EVENT_RUNNING_CORE=0

--- a/microcontroller-src/test/test_kiss_protocol/test_kiss_protocol.cpp
+++ b/microcontroller-src/test/test_kiss_protocol/test_kiss_protocol.cpp
@@ -11,6 +11,7 @@ struct CapturedCommand {
 };
 
 static CapturedCommand captured;
+static CapturedCommand capturedAx25;
 
 void handleCommands(RcvCommand command, uint8_t *params, size_t param_len) {
   captured.called = true;
@@ -18,6 +19,15 @@ void handleCommands(RcvCommand command, uint8_t *params, size_t param_len) {
   captured.payloadLen = param_len;
   if (param_len > 0) {
     memcpy(captured.payload, params, param_len);
+  }
+}
+
+void handleAx25Data(uint8_t *ax25, size_t ax25_len) {
+  capturedAx25.called = true;
+  capturedAx25.command = COMMAND_RCV_UNKNOWN;
+  capturedAx25.payloadLen = ax25_len;
+  if (ax25_len > 0) {
+    memcpy(capturedAx25.payload, ax25, ax25_len);
   }
 }
 
@@ -60,11 +70,15 @@ static void resetCaptured() {
   captured.command = COMMAND_RCV_UNKNOWN;
   captured.payloadLen = 0;
   memset(captured.payload, 0, sizeof(captured.payload));
+  capturedAx25.called = false;
+  capturedAx25.command = COMMAND_RCV_UNKNOWN;
+  capturedAx25.payloadLen = 0;
+  memset(capturedAx25.payload, 0, sizeof(capturedAx25.payload));
 }
 
 static void parseBytes(const uint8_t *data, size_t len) {
   FakeStream stream(data, len);
-  KissParser parser(stream, &handleCommands);
+  KissParser parser(stream, &handleCommands, &handleAx25Data);
   while (stream.available() > 0) {
     parser.loop();
   }
@@ -78,27 +92,27 @@ void test_data_frame_unescapes_and_dispatches_ax25() {
 
   parseBytes(frame, sizeof(frame));
 
-  TEST_ASSERT_TRUE(captured.called);
-  TEST_ASSERT_EQUAL(COMMAND_HOST_TX_AX25, captured.command);
-  TEST_ASSERT_EQUAL(4, captured.payloadLen);
-  TEST_ASSERT_EQUAL_HEX8(0x11, captured.payload[0]);
-  TEST_ASSERT_EQUAL_HEX8(KISS_FEND, captured.payload[1]);
-  TEST_ASSERT_EQUAL_HEX8(0x22, captured.payload[2]);
-  TEST_ASSERT_EQUAL_HEX8(KISS_FESC, captured.payload[3]);
+  TEST_ASSERT_FALSE(captured.called);
+  TEST_ASSERT_TRUE(capturedAx25.called);
+  TEST_ASSERT_EQUAL(4, capturedAx25.payloadLen);
+  TEST_ASSERT_EQUAL_HEX8(0x11, capturedAx25.payload[0]);
+  TEST_ASSERT_EQUAL_HEX8(KISS_FEND, capturedAx25.payload[1]);
+  TEST_ASSERT_EQUAL_HEX8(0x22, capturedAx25.payload[2]);
+  TEST_ASSERT_EQUAL_HEX8(KISS_FESC, capturedAx25.payload[3]);
 }
 
 void test_multiple_fend_bytes_are_ignored() {
   resetCaptured();
   const uint8_t frame[] = {
     KISS_FEND, KISS_FEND, KISS_CMD_SETHARDWARE,
-    'K', 'V', '4', 'P', KV4P_PROTOCOL_VERSION, COMMAND_HOST_PTT_DOWN,
+    'K', 'V', '4', 'P', KV4P_PROTOCOL_VERSION, COMMAND_HOST_DESIRED_STATE,
     KISS_FEND
   };
 
   parseBytes(frame, sizeof(frame));
 
   TEST_ASSERT_TRUE(captured.called);
-  TEST_ASSERT_EQUAL(COMMAND_HOST_PTT_DOWN, captured.command);
+  TEST_ASSERT_EQUAL(COMMAND_HOST_DESIRED_STATE, captured.command);
   TEST_ASSERT_EQUAL(0, captured.payloadLen);
 }
 
@@ -106,7 +120,7 @@ void test_vendor_frame_validates_prefix_and_version() {
   resetCaptured();
   const uint8_t invalidPrefix[] = {
     KISS_FEND, KISS_CMD_SETHARDWARE,
-    'B', 'A', 'D', '!', KV4P_PROTOCOL_VERSION, COMMAND_HOST_PTT_DOWN,
+    'B', 'A', 'D', '!', KV4P_PROTOCOL_VERSION, COMMAND_HOST_DESIRED_STATE,
     KISS_FEND
   };
 
@@ -117,7 +131,7 @@ void test_vendor_frame_validates_prefix_and_version() {
   resetCaptured();
   const uint8_t invalidVersion[] = {
     KISS_FEND, KISS_CMD_SETHARDWARE,
-    'K', 'V', '4', 'P', 0x02, COMMAND_HOST_PTT_DOWN,
+    'K', 'V', '4', 'P', 0x02, COMMAND_HOST_DESIRED_STATE,
     KISS_FEND
   };
 

--- a/microcontroller-src/test/test_kiss_protocol/test_kiss_protocol.cpp
+++ b/microcontroller-src/test/test_kiss_protocol/test_kiss_protocol.cpp
@@ -1,0 +1,163 @@
+#include <Arduino.h>
+#include <unity.h>
+
+#include "protocol.h"
+
+struct CapturedCommand {
+  bool called;
+  RcvCommand command;
+  uint8_t payload[KISS_MAX_FRAME_SIZE];
+  size_t payloadLen;
+};
+
+static CapturedCommand captured;
+
+void handleCommands(RcvCommand command, uint8_t *params, size_t param_len) {
+  captured.called = true;
+  captured.command = command;
+  captured.payloadLen = param_len;
+  if (param_len > 0) {
+    memcpy(captured.payload, params, param_len);
+  }
+}
+
+class FakeStream : public Stream {
+public:
+  FakeStream(const uint8_t *data, size_t len) : _data(data), _len(len), _index(0) {}
+
+  int available() override {
+    return _len - _index;
+  }
+
+  int read() override {
+    if (_index >= _len) {
+      return -1;
+    }
+    return _data[_index++];
+  }
+
+  int peek() override {
+    if (_index >= _len) {
+      return -1;
+    }
+    return _data[_index];
+  }
+
+  void flush() override {}
+
+  size_t write(uint8_t) override {
+    return 1;
+  }
+
+private:
+  const uint8_t *_data;
+  size_t _len;
+  size_t _index;
+};
+
+static void resetCaptured() {
+  captured.called = false;
+  captured.command = COMMAND_RCV_UNKNOWN;
+  captured.payloadLen = 0;
+  memset(captured.payload, 0, sizeof(captured.payload));
+}
+
+static void parseBytes(const uint8_t *data, size_t len) {
+  FakeStream stream(data, len);
+  KissParser parser(stream, &handleCommands);
+  while (stream.available() > 0) {
+    parser.loop();
+  }
+}
+
+void test_data_frame_unescapes_and_dispatches_ax25() {
+  resetCaptured();
+  const uint8_t frame[] = {
+    KISS_FEND, KISS_CMD_DATA, 0x11, KISS_FESC, KISS_TFEND, 0x22, KISS_FESC, KISS_TFESC, KISS_FEND
+  };
+
+  parseBytes(frame, sizeof(frame));
+
+  TEST_ASSERT_TRUE(captured.called);
+  TEST_ASSERT_EQUAL(COMMAND_HOST_TX_AX25, captured.command);
+  TEST_ASSERT_EQUAL(4, captured.payloadLen);
+  TEST_ASSERT_EQUAL_HEX8(0x11, captured.payload[0]);
+  TEST_ASSERT_EQUAL_HEX8(KISS_FEND, captured.payload[1]);
+  TEST_ASSERT_EQUAL_HEX8(0x22, captured.payload[2]);
+  TEST_ASSERT_EQUAL_HEX8(KISS_FESC, captured.payload[3]);
+}
+
+void test_multiple_fend_bytes_are_ignored() {
+  resetCaptured();
+  const uint8_t frame[] = {
+    KISS_FEND, KISS_FEND, KISS_CMD_SETHARDWARE,
+    'K', 'V', '4', 'P', KV4P_PROTOCOL_VERSION, COMMAND_HOST_PTT_DOWN,
+    KISS_FEND
+  };
+
+  parseBytes(frame, sizeof(frame));
+
+  TEST_ASSERT_TRUE(captured.called);
+  TEST_ASSERT_EQUAL(COMMAND_HOST_PTT_DOWN, captured.command);
+  TEST_ASSERT_EQUAL(0, captured.payloadLen);
+}
+
+void test_vendor_frame_validates_prefix_and_version() {
+  resetCaptured();
+  const uint8_t invalidPrefix[] = {
+    KISS_FEND, KISS_CMD_SETHARDWARE,
+    'B', 'A', 'D', '!', KV4P_PROTOCOL_VERSION, COMMAND_HOST_PTT_DOWN,
+    KISS_FEND
+  };
+
+  parseBytes(invalidPrefix, sizeof(invalidPrefix));
+
+  TEST_ASSERT_FALSE(captured.called);
+
+  resetCaptured();
+  const uint8_t invalidVersion[] = {
+    KISS_FEND, KISS_CMD_SETHARDWARE,
+    'K', 'V', '4', 'P', 0x02, COMMAND_HOST_PTT_DOWN,
+    KISS_FEND
+  };
+
+  parseBytes(invalidVersion, sizeof(invalidVersion));
+
+  TEST_ASSERT_FALSE(captured.called);
+}
+
+void test_over_mtu_data_frame_is_dropped() {
+  resetCaptured();
+  uint8_t frame[PROTO_MTU + 4];
+  frame[0] = KISS_FEND;
+  frame[1] = KISS_CMD_DATA;
+  memset(frame + 2, 0x55, PROTO_MTU + 1);
+  frame[sizeof(frame) - 1] = KISS_FEND;
+
+  parseBytes(frame, sizeof(frame));
+
+  TEST_ASSERT_FALSE(captured.called);
+}
+
+void test_unknown_escape_drops_frame() {
+  resetCaptured();
+  const uint8_t frame[] = {
+    KISS_FEND, KISS_CMD_DATA, 0x11, KISS_FESC, 0x99, 0x22, KISS_FEND
+  };
+
+  parseBytes(frame, sizeof(frame));
+
+  TEST_ASSERT_FALSE(captured.called);
+}
+
+void setup() {
+  UNITY_BEGIN();
+  RUN_TEST(test_data_frame_unescapes_and_dispatches_ax25);
+  RUN_TEST(test_multiple_fend_bytes_are_ignored);
+  RUN_TEST(test_vendor_frame_validates_prefix_and_version);
+  RUN_TEST(test_over_mtu_data_frame_is_dropped);
+  RUN_TEST(test_unknown_escape_drops_frame);
+  UNITY_END();
+}
+
+void loop() {}


### PR DESCRIPTION
This replaces the custom kv4p serial protocol with KISS framing, so the module can behave like a standard KISS TNC over serial.

AX.25 packets now use standard KISS DATA frames in both directions, allowing compatible external software to talk to the module directly. This has been tested with `APRSDroid`.

kv4p-specific control, audio, debug, version, and state messages are carried in KISS SETHARDWARE/vendor frames using a `KV4P` payload prefix plus a protocol version byte. The old `DE AD BE EF` delimiter and top-level length field are removed.

I also used this opportunity to refactor the kv4p vendor protocol. Instead of sending one-off commands, Android and firmware now exchange state snapshots. The protocol detects state mismatches and retries updates when needed.

**Highlights**

* Replace custom firmware/Android serial framing with KISS encode/decode.
* Use standard KISS DATA frames for AX.25 TX/RX.
* Send kv4p-specific traffic via KISS SETHARDWARE/vendor frames.
* Persist radio settings in firmware NVS so the radio can initialize on startup without waiting for Android.
* Include initial `DeviceState` in `HELLO` so Android can sync UI/controller state from firmware.
* Add `COMMAND_HOST_DESIRED_STATE` / `COMMAND_DEVICE_STATE` state exchange.
* Add Android `RadioModuleController` to track desired/applied radio state with bounded retries.
* Keep scanning owned by Android, using firmware squelch/device-state reports.
* Add firmware and Android KISS parser/encoder tests.
* Update protocol documentation.
