### PR TITLE
Fix empty NVS HELLO seeding radio defaults

### DIFF
--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioModuleController.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioModuleController.java
@@ -44,13 +44,15 @@ public class RadioModuleController {
             | Protocol.HOST_STATE_FILTER_PRE
             | Protocol.HOST_STATE_FILTER_HIGH
             | Protocol.HOST_STATE_FILTER_LOW;
+    private static final int DEFAULT_DESIRED_FLAGS =
+        Protocol.HOST_STATE_HIGH_POWER | Protocol.HOST_STATE_RSSI_ENABLED;
 
     private Protocol.Sender sender;
     private Protocol.FirmwareVersion firmwareVersion;
     private Protocol.HostDesiredState desiredState = Protocol.HostDesiredState.builder()
         .sequence(0)
         .memoryId(-1)
-        .flags(Protocol.HOST_STATE_HIGH_POWER | Protocol.HOST_STATE_RSSI_ENABLED)
+        .flags(DEFAULT_DESIRED_FLAGS)
         .bw(DRA818_25K)
         .freqTx(0.0f)
         .freqRx(0.0f)
@@ -316,6 +318,19 @@ public class RadioModuleController {
     }
 
     private Protocol.HostDesiredState desiredFromDeviceState(Protocol.DeviceState state) {
+        if (!state.hasRadioConfig()) {
+            return Protocol.HostDesiredState.builder()
+                .sequence(state.getAppliedSequence())
+                .memoryId(-1)
+                .flags(DEFAULT_DESIRED_FLAGS)
+                .bw(DRA818_25K)
+                .freqTx(0.0f)
+                .freqRx(0.0f)
+                .ctcssTx((byte) 0)
+                .squelch((byte) 0)
+                .ctcssRx((byte) 0)
+                .build();
+        }
         return Protocol.HostDesiredState.builder()
             .sequence(state.getAppliedSequence())
             .memoryId(state.getMemoryId())

--- a/android-src/KV4PHT/app/src/test/java/com/vagell/kv4pht/radio/ProtocolKissTest.java
+++ b/android-src/KV4PHT/app/src/test/java/com/vagell/kv4pht/radio/ProtocolKissTest.java
@@ -704,6 +704,52 @@ public class ProtocolKissTest {
     }
 
     @Test
+    public void seedFromDeviceStateWithoutRadioConfigKeepsControllerDefaults() {
+        CapturingSender sender = new CapturingSender();
+        RadioModuleController controller = new RadioModuleController();
+        controller.attachSender(sender);
+        controller.setMemoryId(99);
+        controller.setBandwidth(Protocol.DRA818_12K5);
+        controller.setTxFrequency(446.0f);
+        controller.setRxFrequency(445.5f);
+        controller.setTxTone((byte) 4);
+        controller.setSquelch(5);
+        controller.setRxTone((byte) 6);
+        Protocol.DeviceState emptyNvsState = Protocol.DeviceState.builder()
+            .appliedSequence(7)
+            .memoryId(0)
+            .flags(0)
+            .bw(Protocol.DRA818_12K5)
+            .freqTx(0.0f)
+            .freqRx(0.0f)
+            .ctcssTx((byte) 0)
+            .squelch((byte) 0)
+            .ctcssRx((byte) 0)
+            .radioModuleStatus(Protocol.RadioStatus.RADIO_STATUS_FOUND)
+            .mode(Protocol.DeviceMode.DEVICE_MODE_STOPPED)
+            .lastError(0)
+            .latestRssi(0)
+            .build();
+
+        controller.seedFromDeviceState(emptyNvsState);
+        controller.markTransportReady();
+        controller.setHighPower(false);
+
+        assertEquals(1, sender.sentStates.size());
+        Protocol.HostDesiredState sent = sender.sentStates.get(0);
+        assertEquals(Protocol.DRA818_25K, sent.getBw());
+        assertEquals(-1, sent.getMemoryId());
+        assertEquals(0.0f, sent.getFreqTx(), 0.0001f);
+        assertEquals(0.0f, sent.getFreqRx(), 0.0001f);
+        assertEquals(0, sent.getCtcssTx());
+        assertEquals(0, sent.getSquelch());
+        assertEquals(0, sent.getCtcssRx());
+        assertEquals(0, sent.getFlags() & Protocol.HOST_STATE_RADIO_CONFIG_VALID);
+        assertEquals(0, sent.getFlags() & Protocol.HOST_STATE_HIGH_POWER);
+        assertNotEquals(0, sent.getFlags() & Protocol.HOST_STATE_RSSI_ENABLED);
+    }
+
+    @Test
     public void deviceStateParsesPackedFirmwareStruct() {
         java.nio.ByteBuffer deviceStatePayload = java.nio.ByteBuffer.allocate(26).order(java.nio.ByteOrder.LITTLE_ENDIAN);
         deviceStatePayload.putInt(9);


### PR DESCRIPTION
When firmware reports a DeviceState without valid radio config, avoid copying zero-filled HELLO fields into Android desired state. Reset radio config fields to known defaults instead, preventing stale or empty NVS state from forcing 12.5 kHz bandwidth or carrying values from a previously connected module.
