### PR TITLE
Use -O3 for release firmware builds

### DIFF
--- a/microcontroller-src/platformio.ini
+++ b/microcontroller-src/platformio.ini
@@ -33,10 +33,13 @@ lib_deps =
 [env:esp32dev-release]
 build_type = release
 extends = env:esp32dev
+build_unflags =
+  -Os
 build_flags =
   -DARDUINO_RUNNING_CORE=1
   -DARDUINO_EVENT_RUNNING_CORE=0
   -DRELEASE=1
+  -O3
 
 [env:native-tests]
 build_type = test


### PR DESCRIPTION
Switch the release PlatformIO environment from -Os to -O3.

Fixes #411