### PR TITLE
Fix radio state sync bounce

### DIFF
--- a/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
+++ b/android-src/KV4PHT/app/src/main/java/com/vagell/kv4pht/radio/RadioAudioService.java
@@ -1475,6 +1475,9 @@ public class RadioAudioService extends Service {
         if (!state.hasRadioConfig() || state.getLastError() != 0) {
             return;
         }
+        if (!radioModule.isAppliedStateInSync()) {
+            return;
+        }
         String nextFrequency = formatFreq(state.getFreqRx());
         int nextMemoryId = state.getMemoryId();
         if (nextMemoryId == activeMemoryId && nextFrequency.equals(activeFrequencyStr)) {


### PR DESCRIPTION
Every incoming DeviceState was allowed to mirror firmware’s applied memory/frequency back into service/UI state, even while Android had a newer desired memory change in flight.