### PR TITLE
Fix soft squelch transition after TX

### DIFF
--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/dsp/softSquelchEffect.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/dsp/softSquelchEffect.h
@@ -75,11 +75,6 @@ public:
     if (!active()) {
       return input;
     }
-    if (isBypassed()) {
-      cordonSamplesRemaining = 0;
-      setSoftSqOpen(true);
-      return input;
-    }
 
     float x = (float)input / 32768.0f;
     float filtered = bpf.filter(x);
@@ -104,6 +99,9 @@ public:
   }
 
   bool isSoftOpen() const {
+    if (isBypassed()) {
+      return true;
+    }
     if (cordonSamplesRemaining > 0) {
       return cordonedSoftSqOpen;
     }

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/dsp/softSquelchEffect.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/dsp/softSquelchEffect.h
@@ -48,12 +48,6 @@ public:
   void resetState() {
     memset(bpfState, 0, sizeof(bpfState));
     previousOutsideSample = 0.0f;
-    if (isBypassed()) {
-      iirZcr = 0.0f;
-      aboveThresholdSamples = 0;
-      setSoftSqOpen(true);
-      return;
-    }
     iirZcr = resetClosedZcr();
     aboveThresholdSamples = closeDelaySamples();
     setSoftSqOpen(false);

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/dsp/softSquelchEffect.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/dsp/softSquelchEffect.h
@@ -26,6 +26,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define ZCR_DECAY_TIME 0.100f  // seconds
 #define SQ_CLOSE_DELAY 0.250f  // seconds
+#define SQ_TRANSITION_CORDON_TIME (SQ_CLOSE_DELAY + 0.750f)  // seconds
 
 class SoftSquelchEffect : public AudioEffect {
 public:
@@ -48,13 +49,35 @@ public:
   void resetState() {
     memset(bpfState, 0, sizeof(bpfState));
     previousOutsideSample = 0.0f;
+    cordonSamplesRemaining = 0;
+    if (isBypassed()) {
+      iirZcr = 0.0f;
+      aboveThresholdSamples = 0;
+      setSoftSqOpen(true);
+      return;
+    }
     iirZcr = resetClosedZcr();
     aboveThresholdSamples = closeDelaySamples();
     setSoftSqOpen(false);
   }
 
+  void cordonTransition() {
+    if (isBypassed()) {
+      cordonSamplesRemaining = 0;
+      setSoftSqOpen(true);
+      return;
+    }
+    cordonedSoftSqOpen = isSoftOpen();
+    cordonSamplesRemaining = transitionCordonSamples();
+  }
+
   effect_t process(effect_t input) override {
     if (!active()) {
+      return input;
+    }
+    if (isBypassed()) {
+      cordonSamplesRemaining = 0;
+      setSoftSqOpen(true);
       return input;
     }
 
@@ -70,6 +93,9 @@ public:
     float crossingInstantRate = crossing ? (float)sampleRate : 0.0f;
     iirZcr += zcrAlpha * (crossingInstantRate - iirZcr);
     updateDecision();
+    if (cordonSamplesRemaining > 0) {
+      cordonSamplesRemaining--;
+    }
     return input;
   }
 
@@ -78,6 +104,9 @@ public:
   }
 
   bool isSoftOpen() const {
+    if (cordonSamplesRemaining > 0) {
+      return cordonedSoftSqOpen;
+    }
     return softSqOpen;
   }
 
@@ -87,6 +116,7 @@ public:
     }
     deadbandLevel = level;
     deadband = deadbandForLevel(level);
+    resetState();
   }
 
   uint8_t getDeadbandLevel() const {
@@ -114,7 +144,9 @@ private:
   float zcrAlpha = 0.0f;
   float iirZcr = 0.0f;
   uint32_t aboveThresholdSamples = 0;
+  uint32_t cordonSamplesRemaining = 0;
   bool softSqOpen = false;
+  bool cordonedSoftSqOpen = false;
   uint8_t deadbandLevel = 0;
   float deadband = 0.45f;
 
@@ -123,6 +155,10 @@ private:
       level = 8;
     }
     return 0.45f - ((float)level / 8.0f) * (0.45f - 0.08f);
+  }
+
+  bool isBypassed() const {
+    return deadbandLevel == 0;
   }
 
   void initBpf() {
@@ -137,6 +173,10 @@ private:
 
   uint32_t closeDelaySamples() const {
     return (uint32_t)((float)sampleRate * closeDelaySec);
+  }
+
+  uint32_t transitionCordonSamples() const {
+    return (uint32_t)((float)sampleRate * SQ_TRANSITION_CORDON_TIME);
   }
 
   float resetClosedZcr() const {

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/dsp/softSquelchEffect.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/dsp/softSquelchEffect.h
@@ -26,7 +26,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define ZCR_DECAY_TIME 0.100f  // seconds
 #define SQ_CLOSE_DELAY 0.250f  // seconds
-#define SQ_TRANSITION_CORDON_TIME (SQ_CLOSE_DELAY + 0.750f)  // seconds
 
 class SoftSquelchEffect : public AudioEffect {
 public:
@@ -49,7 +48,6 @@ public:
   void resetState() {
     memset(bpfState, 0, sizeof(bpfState));
     previousOutsideSample = 0.0f;
-    cordonSamplesRemaining = 0;
     if (isBypassed()) {
       iirZcr = 0.0f;
       aboveThresholdSamples = 0;
@@ -61,18 +59,12 @@ public:
     setSoftSqOpen(false);
   }
 
-  void cordonTransition() {
-    if (isBypassed()) {
-      cordonSamplesRemaining = 0;
-      setSoftSqOpen(true);
-      return;
-    }
-    cordonedSoftSqOpen = isSoftOpen();
-    cordonSamplesRemaining = transitionCordonSamples();
+  void setHardwareSquelched(bool squelched) {
+    hardwareSquelched = squelched;
   }
 
   effect_t process(effect_t input) override {
-    if (!active()) {
+    if (!active() || hardwareSquelched) {
       return input;
     }
 
@@ -88,9 +80,6 @@ public:
     float crossingInstantRate = crossing ? (float)sampleRate : 0.0f;
     iirZcr += zcrAlpha * (crossingInstantRate - iirZcr);
     updateDecision();
-    if (cordonSamplesRemaining > 0) {
-      cordonSamplesRemaining--;
-    }
     return input;
   }
 
@@ -101,9 +90,6 @@ public:
   bool isSoftOpen() const {
     if (isBypassed()) {
       return true;
-    }
-    if (cordonSamplesRemaining > 0) {
-      return cordonedSoftSqOpen;
     }
     return softSqOpen;
   }
@@ -142,9 +128,8 @@ private:
   float zcrAlpha = 0.0f;
   float iirZcr = 0.0f;
   uint32_t aboveThresholdSamples = 0;
-  uint32_t cordonSamplesRemaining = 0;
   bool softSqOpen = false;
-  bool cordonedSoftSqOpen = false;
+  bool hardwareSquelched = false;
   uint8_t deadbandLevel = 0;
   float deadband = 0.45f;
 
@@ -171,10 +156,6 @@ private:
 
   uint32_t closeDelaySamples() const {
     return (uint32_t)((float)sampleRate * closeDelaySec);
-  }
-
-  uint32_t transitionCordonSamples() const {
-    return (uint32_t)((float)sampleRate * SQ_TRANSITION_CORDON_TIME);
   }
 
   float resetClosedZcr() const {

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
@@ -415,6 +415,7 @@ void setup() {
   digitalWrite(hw.pins.pinPd, HIGH);  // Power on
   pinMode(hw.pins.pinPtt, OUTPUT);
   digitalWrite(hw.pins.pinPtt, HIGH);  // Rx
+  pinMode(hw.pins.pinSq, INPUT);
   if (hw.features.hasHL) {
     pinMode(hw.pins.pinHl, OUTPUT);
     digitalWrite(hw.pins.pinHl, LOW);  // High power

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/rxAudio.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/rxAudio.h
@@ -139,7 +139,7 @@ void initI2SRx() {
   if (rxStreamConfigured) {
     return;
   }
-  softSquelchEffect.resetState();
+  softSquelchEffect.cordonTransition();
   injectADCBias();
   setUpADCAttenuator();
   //AudioToolsLogger.begin(debugPrinter, AudioToolsLogLevel::Debug);

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/rxAudio.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/rxAudio.h
@@ -139,7 +139,6 @@ void initI2SRx() {
   if (rxStreamConfigured) {
     return;
   }
-  softSquelchEffect.cordonTransition();
   injectADCBias();
   setUpADCAttenuator();
   //AudioToolsLogger.begin(debugPrinter, AudioToolsLogLevel::Debug);
@@ -179,6 +178,7 @@ void endI2SRx() {
 }
   
 void rxAudioLoop() {
+  softSquelchEffect.setHardwareSquelched(digitalRead(hw.pins.pinSq) == HIGH);
   if (mode == MODE_RX || mode == MODE_STOPPED) {
     mute.setActive(squelched);
     rxCopier.copy();


### PR DESCRIPTION
Use the radio module SQ pin to pause soft squelch DSP during RX/TX transitions.

While the SQ pin is closed, the module is outputting artificial silence, so the firmware keeps the current soft squelch state instead of feeding that silence into the detector. Once the SQ pin opens, detection continues from the same state.

Fixes #434
