### PR TITLE
TX timeout

### DIFF
--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/globals.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/globals.h
@@ -36,6 +36,10 @@ enum RfModuleType : uint8_t {
 #define AUDIO_RESAMPLE_RATIO 3
 #define AUDIO_DSP_ALIGN16 __attribute__((aligned(16)))
 
+static constexpr uint16_t TX_AUDIO_TIMEOUT_FRAMES = 50;
+static constexpr uint32_t TX_AUDIO_TIMEOUT_MS =
+  (uint32_t)TX_AUDIO_TIMEOUT_FRAMES * AUDIO_FRAME_SAMPLES_WIRE * 1000 / AUDIO_WIRE_SAMPLE_RATE;
+
 inline uint32_t bluetoothDeviceId() {
   uint64_t mac = ESP.getEfuseMac();
   return (uint32_t)((mac >> 24) & 0xFFFFFF);

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
@@ -25,6 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "BluedroidBleKissGattStream.h"
 #include "led.h"
 #include "protocol.h"
+#include "state.h"
 #include "rxAudio.h"
 #include "txAudio.h"
 #include "buttons.h"
@@ -65,31 +66,6 @@ bool bluetoothProtocolConnected = false;
 bool bleKissProtocolConnected = false;
 KissParser bluetoothParser(protocolBtSession, &handleCommands, &handleAx25Data);
 KissParser bleKissParser(protocolBleSession, &handleCommands, &handleAx25Data);
-
-// Were we able to communicate with the radio module during setup()?
-const char RADIO_MODULE_NOT_FOUND = 'x';
-const char RADIO_MODULE_FOUND     = 'f';
-char radioModuleStatus            = RADIO_MODULE_NOT_FOUND;
-
-boolean rssiOn = true; // true if RSSI is enabled
-HostDesiredState desiredState = {
-  .sequence = 0,
-  .memoryId = -1,
-  .flags = HOST_STATE_HIGH_POWER | HOST_STATE_RSSI_ENABLED,
-  .bw = DRA818_25K,
-  .freq_tx = 0.0f,
-  .freq_rx = 0.0f,
-  .ctcss_tx = 0,
-  .squelch = 0,
-  .ctcss_rx = 0,
-};
-HostDesiredState appliedState = {};
-HostDesiredState persistedState = {};
-bool radioConfigApplied = false;
-bool filtersApplied = false;
-uint8_t lastDeviceStateError = DEVICE_STATE_ERROR_NONE;
-uint8_t latestRssi = 0;
-bool deviceStateDirty = false;
 
 float moduleMinRadioFreq() {
   return hw.rfModuleType == RF_SA818_UHF ? 400.0f : 134.0f;
@@ -366,6 +342,7 @@ void setMode(Mode newMode) {
     case MODE_TX:
       _LOGI("MODE_TX");
       txStartTime = millis();
+      txWatchDog.reset(txStartTime);
       digitalWrite(hw.pins.pinPtt, LOW);
       endI2SRx();
       initI2STx();

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/state.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/state.h
@@ -1,0 +1,44 @@
+/*
+KV4P-HT (see http://kv4p.com)
+Copyright (C) 2026 Vance Vagell
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#pragma once
+
+#include "protocol.h"
+
+const char RADIO_MODULE_NOT_FOUND = 'x';
+const char RADIO_MODULE_FOUND = 'f';
+
+char radioModuleStatus = RADIO_MODULE_NOT_FOUND;
+boolean rssiOn = true;
+HostDesiredState desiredState = {
+  .sequence = 0,
+  .memoryId = -1,
+  .flags = HOST_STATE_HIGH_POWER | HOST_STATE_RSSI_ENABLED,
+  .bw = DRA818_25K,
+  .freq_tx = 0.0f,
+  .freq_rx = 0.0f,
+  .ctcss_tx = 0,
+  .squelch = 0,
+  .ctcss_rx = 0,
+};
+HostDesiredState appliedState = {};
+HostDesiredState persistedState = {};
+bool radioConfigApplied = false;
+bool filtersApplied = false;
+uint8_t lastDeviceStateError = DEVICE_STATE_ERROR_NONE;
+uint8_t latestRssi = 0;
+bool deviceStateDirty = false;

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/txAudio.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/txAudio.h
@@ -145,21 +145,26 @@ void processTxAx25(uint8_t *src, size_t len) {
   afskMod.modulate(src, len, txAfskBlock, TX_AFSK_BLOCK_SAMPLES, TX_AFSK_LEAD_SILENCE_MS, TX_AFSK_TAIL_SILENCE_MS);
 }
 
+void releaseHostPtt() {
+  if (desiredState.flags & HOST_STATE_PTT_REQUESTED) {
+    desiredState.flags &= ~HOST_STATE_PTT_REQUESTED;
+    desiredState.sequence++;
+  }
+  setMode(rxIdleMode());
+  markDeviceStateDirty();
+}
+
 void inline txAudioLoop() {
   if (mode == MODE_TX) {
     if ((desiredState.flags & HOST_STATE_PTT_REQUESTED) && txWatchDog.expired(millis())) {
       _LOGW("TX audio timeout; releasing host PTT");
-      desiredState.flags &= ~HOST_STATE_PTT_REQUESTED;
-      setMode(rxIdleMode());
-      markDeviceStateDirty();
+      releaseHostPtt();
       esp_task_wdt_reset();
       return;
     }
     // Check for runaway tx
     if ((millis() - txStartTime) > RUNAWAY_TX_SEC * 1000) {
-      desiredState.flags &= ~HOST_STATE_PTT_REQUESTED;
-      setMode(rxIdleMode());
-      markDeviceStateDirty();
+      releaseHostPtt();
       esp_task_wdt_reset();
     }
   }

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/txAudio.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/txAudio.h
@@ -24,6 +24,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <AfskModulator.h>
 #include "globals.h"
 #include "protocol.h"
+#include "state.h"
+#include "utils.h"
 #include "dsp/audioResampler.h"
 
 bool txStreamConfigured = false;
@@ -39,6 +41,10 @@ EncodedAudioStream txDecodeStream(&txVolumeMeter, &txAdpcmDecoder);
 // Tx runaway detection stuff
 uint32_t txStartTime = -1;
 const uint16_t RUNAWAY_TX_SEC = 200;
+
+// A host holding PTT must continuously provide voice frames. This releases PTT
+// quickly if USB, Bluetooth, or BLE disappears without sending PTT-up.
+TxWatchDog txWatchDog;
 
 float txAfskBlock[TX_AFSK_BLOCK_SAMPLES];
 int16_t txAfskPcm[TX_AFSK_BLOCK_SAMPLES];
@@ -126,6 +132,7 @@ void processTxAudio(uint8_t *src, size_t len) {
   if (!src || len == 0 || !txStreamConfigured) {
     return;
   }
+  txWatchDog.onFrame(millis());
   txDecodeStream.write(src, len);
   updateTxAudioLevel(txVolumeMeter.volumeRatio());
   esp_task_wdt_reset();
@@ -140,9 +147,19 @@ void processTxAx25(uint8_t *src, size_t len) {
 
 void inline txAudioLoop() {
   if (mode == MODE_TX) {
+    if ((desiredState.flags & HOST_STATE_PTT_REQUESTED) && txWatchDog.expired(millis())) {
+      _LOGW("TX audio timeout; releasing host PTT");
+      desiredState.flags &= ~HOST_STATE_PTT_REQUESTED;
+      setMode(rxIdleMode());
+      markDeviceStateDirty();
+      esp_task_wdt_reset();
+      return;
+    }
     // Check for runaway tx
     if ((millis() - txStartTime) > RUNAWAY_TX_SEC * 1000) {
+      desiredState.flags &= ~HOST_STATE_PTT_REQUESTED;
       setMode(rxIdleMode());
+      markDeviceStateDirty();
       esp_task_wdt_reset();
     }
   }

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/utils.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/utils.h
@@ -55,3 +55,21 @@ public:
     lastDebounceTime = millis();
   }
 };
+
+class TxWatchDog {
+public:
+  void reset(uint32_t now) {
+    lastFrameTime = now;
+  }
+
+  void onFrame(uint32_t now) {
+    lastFrameTime = now;
+  }
+
+  bool expired(uint32_t now) const {
+    return (uint32_t)(now - lastFrameTime) >= TX_AUDIO_TIMEOUT_MS;
+  }
+
+private:
+  uint32_t lastFrameTime = 0;
+};

--- a/microcontroller-src/platformio.ini
+++ b/microcontroller-src/platformio.ini
@@ -50,6 +50,7 @@ test_build_src = no
 test_filter =
   test_kiss_protocol
   test_audio_codec
+  test_tx_audio_watchdog
 build_flags =
   -DPIO_NATIVE_TEST=1
   -std=gnu++17

--- a/microcontroller-src/test/native_stubs/Arduino.h
+++ b/microcontroller-src/test/native_stubs/Arduino.h
@@ -23,6 +23,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <cstring>
 #include <cstdio>
 
+inline unsigned long millis() {
+  return 0;
+}
+
 class NativeEsp {
 public:
   uint64_t getEfuseMac() const {

--- a/microcontroller-src/test/test_tx_audio_watchdog/test_tx_audio_watchdog.cpp
+++ b/microcontroller-src/test/test_tx_audio_watchdog/test_tx_audio_watchdog.cpp
@@ -1,0 +1,65 @@
+/*
+KV4P-HT (see http://kv4p.com)
+Copyright (C) 2026 Vance Vagell
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <Arduino.h>
+#include <unity.h>
+
+#include "utils.h"
+
+void test_timeout_is_derived_from_fifty_audio_frames() {
+  TEST_ASSERT_EQUAL_UINT16(50, TX_AUDIO_TIMEOUT_FRAMES);
+  TEST_ASSERT_EQUAL_UINT32(778, TX_AUDIO_TIMEOUT_MS);
+}
+
+void test_watchdog_remains_active_before_timeout() {
+  TxWatchDog watchdog;
+  watchdog.reset(0);
+  TEST_ASSERT_FALSE(watchdog.expired(TX_AUDIO_TIMEOUT_MS - 1));
+}
+
+void test_watchdog_expires_at_timeout() {
+  TxWatchDog watchdog;
+  watchdog.reset(0);
+  TEST_ASSERT_TRUE(watchdog.expired(TX_AUDIO_TIMEOUT_MS));
+}
+
+void test_audio_frame_restarts_timeout() {
+  TxWatchDog watchdog;
+  watchdog.reset(0);
+  watchdog.onFrame(TX_AUDIO_TIMEOUT_MS - 1);
+  TEST_ASSERT_FALSE(watchdog.expired(TX_AUDIO_TIMEOUT_MS));
+  TEST_ASSERT_TRUE(watchdog.expired((TX_AUDIO_TIMEOUT_MS * 2) - 1));
+}
+
+void test_timeout_handles_millis_wraparound() {
+  TxWatchDog watchdog;
+  uint32_t lastFrame = UINT32_MAX - 100;
+  uint32_t now = TX_AUDIO_TIMEOUT_MS - 101;
+  watchdog.reset(lastFrame);
+  TEST_ASSERT_TRUE(watchdog.expired(now));
+}
+
+int main(int, char **) {
+  UNITY_BEGIN();
+  RUN_TEST(test_timeout_is_derived_from_fifty_audio_frames);
+  RUN_TEST(test_watchdog_remains_active_before_timeout);
+  RUN_TEST(test_watchdog_expires_at_timeout);
+  RUN_TEST(test_audio_frame_restarts_timeout);
+  RUN_TEST(test_timeout_handles_millis_wraparound);
+  return UNITY_END();
+}


### PR DESCRIPTION
Add a firmware-side TX audio watchdog that releases PTT when host audio frames stop arriving. This prevents the radio from remaining keyed after a USB, Bluetooth, or BLE connection disappears without sending PTT-up.