### PR TITLE
Update firmware README.md

### DIFF
--- a/microcontroller-src/README.md
+++ b/microcontroller-src/README.md
@@ -139,14 +139,7 @@ You can use either Platform IO or Arduino IDE as your build environment.
 
 ### Install Required Libraries
 
-1. **Install EspSoftwareSerial:**
-
-   - Navigate to `Sketch` > `Include Library` > `Manage Libraries`.
-   - In the **Library Manager** window, enter **"EspSoftwareSerial"** into the search bar.
-   - Locate the **EspSoftwareSerial** library in the search results.
-   - Click the **Install** button to add the library to your Arduino environment.
-
-2. **Install DRA818:**
+1. Install DRA818:**
 
    > **Note:** The version of the DRA818 library available through the Arduino Library Manager is currently broken. To ensure proper functionality, you need to install it manually from the official GitHub release.
 
@@ -161,7 +154,7 @@ You can use either Platform IO or Arduino IDE as your build environment.
      - Select the ZIP file and click **Open**.
      - A confirmation message should appear indicating that the library was added successfully.
 
-3. **Install AudioTools:**
+2. **Install AudioTools:**
 
    - **Download the AudioTools Library ZIP:**
      - Visit the [AudioTools v1.2.3 Release Page](https://github.com/pschatzmann/arduino-audio-tools/releases/tag/v1.2.3).
@@ -174,7 +167,7 @@ You can use either Platform IO or Arduino IDE as your build environment.
      - Select the ZIP file and click **Open**.
      - A confirmation message should appear indicating that the library was added successfully.
 
-4. **Install adpcm:**
+3. **Install adpcm:**
 
    - **Download the adpcm Library ZIP:**
      - Visit the [adpcm v1.2.1 Release Page](https://github.com/pschatzmann/adpcm/releases/tag/v1.2.1).
@@ -187,22 +180,16 @@ You can use either Platform IO or Arduino IDE as your build environment.
      - Select the ZIP file and click **Open**.
      - A confirmation message should appear indicating that the library was added successfully.
 
-5. **Install esp32-afsk:**
+4. **Install esp32-afsk:**
 
-   - **Download the esp32-afsk Library ZIP:**
-     - Visit the [esp32-afsk v0.1.3 Release Page](https://github.com/dkaukov/esp32-afsk/releases/tag/v0.1.3).
-     - Click on the **"Source code (zip)"** link to download the ZIP file of the library.
+   - Navigate to `Sketch` > `Include Library` > `Manage Libraries`.
+   - In the **Library Manager** window, enter **"esp32-afsk"** into the search bar.
+   - Locate the **esp32-afsk** library by **Dmitry Kaukov** in the search results.
+   - Click the **Install** button to add the library to your Arduino environment.
 
-   - **Add the adpcm Library to Arduino IDE:**
-     - Open the Arduino IDE.
-     - Go to `Sketch` > `Include Library` > `Add .ZIP Library...`.
-     - In the file dialog, navigate to the location where you downloaded the `esp32-afk-0.1.3.zip` file.
-     - Select the ZIP file and click **Open**.
-     - A confirmation message should appear indicating that the library was added successfully.
+5. **Confirm All Libraries Are Installed:**
 
-6. **Confirm All Libraries Are Installed:**
-
-   - After completing the above steps, go to `Sketch` > `Include Library` and scroll down to the bottom where you will find the section labeled `Contributed Libraries` (light gray). Ensure that **adpcm**, **audio-tools**,  **DRA818**, **esp32-afk** and **EspSoftwareSerial** are listed.
+   - After completing the above steps, go to `Sketch` > `Include Library` and scroll down to the bottom where you will find the section labeled `Contributed Libraries` (light gray). Ensure that **adpcm**, **audio-tools**,  **DRA818** and **esp32-afk** are listed.
    - If any libraries are missing, revisit the installation steps to ensure they were added correctly.
 
 ### Opening the Project (Arduino IDE)

--- a/microcontroller-src/README.md
+++ b/microcontroller-src/README.md
@@ -151,13 +151,13 @@ You can use either Platform IO or Arduino IDE as your build environment.
    > **Note:** The version of the DRA818 library available through the Arduino Library Manager is currently broken. To ensure proper functionality, you need to install it manually from the official GitHub release.
 
    - **Download the DRA818 Library ZIP:**
-     - Visit the [DRA818 v1.0.1 Release Page](https://github.com/fatpat/arduino-dra818/releases/tag/v1.0.1).
-     - Click on the **"Source code (zip)"** link to download the ZIP file of the library.
+     - Visit this [commit of the DRA818 v1.0.1 library](https://github.com/fatpat/arduino-dra818.git#89582e3ef7bf3f31f1af149e32cec16c4b9e4cf2). It contains additional definitions needed for the `SA818_VHF` and `SA818_UHF` radio modules.
+     - Click the green `Code` button and then `Download ZIP`.
 
    - **Add the DRA818 Library to Arduino IDE:**
      - Open the Arduino IDE.
      - Go to `Sketch` > `Include Library` > `Add .ZIP Library...`.
-     - In the file dialog, navigate to the location where you downloaded the `arduino-dra818-1.0.1.zip` file.
+     - In the file dialog, navigate to the location where you downloaded the `arduino-dra818-master.zip` file.
      - Select the ZIP file and click **Open**.
      - A confirmation message should appear indicating that the library was added successfully.
 

--- a/microcontroller-src/README.md
+++ b/microcontroller-src/README.md
@@ -1,24 +1,25 @@
 ## Table of Contents
 
 - [Table of Contents](#table-of-contents)
-- [Prerequisites](#prerequisites)
+- [Getting Started](#getting-started)
    - [Install ESP32 Drivers](#install-esp32-drivers)
-- [Option 1: Arduino IDE](#option-1-arduino-ide)
+   - [Choose your build environment](#choose-your-build-environment )
+- [Option 1: PlatformIO](#option-1-platformio)
+   - [Install PlatformIO](#install-platformio)
+   - [Opening the Project (PlatformIO)](#opening-the-project-platformio)
+   - [Building the Project (PlatformIO)](#building-the-project-platformio)
+   - [Uploading to the ESP32 (PlatformIO)](#uploading-to-the-esp32-platformio)
+   - [PlatformIO Specific Notes](#platformio-specific-notes)
+- [Option 2: Arduino IDE](#option-2-arduino-ide)
    - [Install Arduino IDE](#install-arduino-ide)
    - [Install ESP32 Board Support](#install-esp32-board-support)
    - [Install Required Libraries](#install-required-libraries)
    - [Opening the Project (Arduino IDE)](#opening-the-project-arduino-ide)
    - [Building the Project (Arduino IDE)](#building-the-project-arduino-ide)
    - [Uploading to the ESP32 (Arduino IDE)](#uploading-to-the-esp32-arduino-ide)
-- [Option 2: PlatformIO](#option-2-platformio)
-   - [Install PlatformIO](#install-platformio)
-   - [Opening the Project (PlatformIO)](#opening-the-project-platformio)
-   - [Building the Project (PlatformIO)](#building-the-project-platformio)
-   - [Uploading to the ESP32 (PlatformIO)](#uploading-to-the-esp32-platformio)
-   - [PlatformIO Specific Notes](#platformio-specific-notes)
 - [Additional Notes](#additional-notes)
 
-## Prerequisites
+## Getting Started
 
 ### Install ESP32 Drivers
 
@@ -29,83 +30,19 @@
    - **Windows:** Check the Device Manager for the COM port associated with your ESP32.
    - **macOS/Linux:** Verify the presence of `/dev/tty.*` devices corresponding to your ESP32.
 
-## Option 1: Arduino IDE
+### Choose Your Build Environment
 
-### Install Arduino IDE
+You can use either Platform IO or Arduino IDE as your build environment. 
 
-1. **Download and Install Arduino IDE:**
-   - Visit the [Arduino Software Page](https://www.arduino.cc/en/software) and download the latest version suitable for your operating system.
-   - Follow the installation instructions provided on the website.
+- **PlatformIO (Preferred):**
+  - Our primary build environment, and the easiest way to get started.
+  - Offers an integrated development environment with advanced features such as dependency management, project configuration, and integrated debugging.
+  - Ideal for users who require more control and flexibility over their development workflow.
+- **Arduino IDE:**
+  - Provides a simpler interface that is beginner-friendly and widely used within the Arduino community.
+  - Unfortunately for a larger project like `kv4p-ht`, the initial setup is less automated and more complex.
 
-### Install ESP32 Board Support
-
-1. **Open Arduino IDE.**
-
-2. **Install ESP32 Boards:**
-   - Go to `Tools` > `Board` > `Boards Manager`.
-   - In the Boards Manager window, search for **"ESP32"**.
-   - Find **"esp32"** by Espressif Systems.
-   - Select version **2.0.17**. The code needs to be updated to support 3.X
-   - Click **Install** and Wait for the installation to complete.
-
-3. **Configure**
-   - Go to `Tools` > `Events Run On` > Select `Core 0`
-      - This is done so audio processing interrupts run on a separate thread for maximum stability.
-
-### Install Required Libraries
-
-1. **Install EspSoftwareSerial:**
-   - Navigate to `Sketch` > `Include Library` > `Manage Libraries`.
-   - In the **Library Manager** window, enter **"EspSoftwareSerial"** into the search bar.
-   - Locate the **EspSoftwareSerial** library in the search results.
-   - Click the **Install** button to add the library to your Arduino environment.
-
-2. **Install DRA818:**
-   > **Note:** The version of the DRA818 library available through the Arduino Library Manager is currently broken. To ensure proper functionality, you need to install it manually from the official GitHub release.
-
-   - **Download the DRA818 Library ZIP:**
-     - Visit the [DRA818 v1.0.1 Release Page](https://github.com/fatpat/arduino-dra818/releases/tag/v1.0.1).
-     - Click on the **"Source code (zip)"** link to download the ZIP file of the library.
-
-   - **Add the DRA818 Library to Arduino IDE:**
-     - Open the Arduino IDE.
-     - Go to `Sketch` > `Include Library` > `Add .ZIP Library...`.
-     - In the file dialog, navigate to the location where you downloaded the `arduino-dra818-1.0.1.zip` file.
-     - Select the ZIP file and click **Open**.
-     - A confirmation message should appear indicating that the library was added successfully.
-
-3. **Confirm All Libraries Are Installed:**
-   - After completing the above steps, ensure that **EspSoftwareSerial** and **DRA818** are listed under `Sketch` > `Include Library`.
-   - If any libraries are missing, revisit the installation steps to ensure they were added correctly.
-
-### Opening the Project (Arduino IDE)
-
-1. **Open the Project:**
-   - Go to `File` > `Open`.
-   - Navigate and open: `kv4p-ht/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino`.
-
-### Building the Project (Arduino IDE)
-
-1. **Select the ESP32 Board:**
-   - Go to `Tools` > `Board` and select **"ESP32 Dev Module"**.
-
-2. **Select the Correct Port:**
-   - Connect your ESP32 to your computer via USB.
-   - Go to `Tools` > `Port` and select the appropriate COM port (Windows) or `/dev/tty.*` device (macOS/Linux).
-
-3. **Verify the Sketch:**
-   - Click the **Verify** button (checkmark) in the Arduino toolbar or press `Ctrl+R` (`Cmd+R` on macOS).
-   - The IDE will compile the sketch and display any errors or warnings in the output pane.
-   - Ensure that the sketch compiles without errors.
-
-### Uploading to the ESP32 (Arduino IDE)
-
-1. **Upload the Firmware:**
-   - Click the **Upload** button (right arrow) in the Arduino toolbar or press `Ctrl+U` (`Cmd+U` on macOS).
-   - The Arduino IDE will compile (if not already done) and upload the firmware to the ESP32.
-   - Monitor the output pane for upload progress and confirmation of success.
-
-## Option 2: PlatformIO
+## Option 1: PlatformIO
 
 ### Install PlatformIO
 
@@ -119,8 +56,8 @@
    - Locate the **PlatformIO IDE** extension by PlatformIO and click **Install**.
 
 3. **Verify Installation:**
-   - After installation, the PlatformIO icon should appear in the VSCode sidebar.
-   - Click the PlatformIO icon to open the PlatformIO Home interface.
+   - After installation, the **PlatformIO** icon (alien head) should appear in the VSCode sidebar.
+   - Click the **PlatformIO** icon to open the PlatformIO Home interface.
 
 ### Opening the Project (PlatformIO)
 
@@ -130,6 +67,7 @@
    - Open this directory in VSCode by selecting `File` > `Open Folder` and choosing the specified path.
    - Ensure that the directory contains the `platformio.ini` file to recognize it as a PlatformIO project.
    - *Note:* Opening the root directory may prevent VSCode from recognizing it as a PlatformIO project.
+   - *Note:* After opening the project, if VSCode shows a notification bar at the top indicating restricted mode, click **Manage** and then **Trust** in the subsequent dialog to enable all capabilities.
 
 ### Building the Project (PlatformIO)
 
@@ -174,15 +112,127 @@
       - When working locally in PlatformIO, perform the rename to benefit from IntelliSense.
       - Before committing changes, revert the file extension back to `.ino` to maintain Arduino IDE compatibility.
 
-## Additional Notes
+## Option 2: Arduino IDE
 
-- **Choosing Between Arduino IDE and PlatformIO:**
-  - **PlatformIO:**
-    - Offers an integrated development environment with advanced features such as dependency management, project configuration, and integrated debugging.
-    - Ideal for users who require more control and flexibility over their development workflow.
-  - **Arduino IDE:**
-    - Provides a simpler interface that is beginner-friendly and widely used within the Arduino community.
-    - Suitable for users who prefer a straightforward setup and are familiar with the Arduino ecosystem.
+### Install Arduino IDE
+
+1. **Download and Install Arduino IDE:**
+   - Visit the [Arduino Software Page](https://www.arduino.cc/en/software) and download the latest version suitable for your operating system.
+   - Follow the installation instructions provided on the website.
+
+### Install ESP32 Board Support
+
+1. **Open Arduino IDE.**
+
+2. **Install ESP32 Boards:**
+   - Go to `Tools` > `Board` > `Boards Manager`.
+   - In the Boards Manager window, search for **"ESP32"**.
+   - Find **"esp32"** by Espressif Systems.
+   - Select version **2.0.17**. The code needs to be updated to support 3.X
+   - Click **Install** and Wait for the installation to complete.
+
+3. **Configure**
+   - Go to `Tools` > `Events Run On` > Select `Core 0`
+     - This is done so audio processing interrupts run on a separate thread for maximum stability.
+   - Go to `Tools` > `Partition Scheme` > Select `Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)`
+     - This optimizes partitions for large code.
+
+### Install Required Libraries
+
+1. **Install EspSoftwareSerial:**
+
+   - Navigate to `Sketch` > `Include Library` > `Manage Libraries`.
+   - In the **Library Manager** window, enter **"EspSoftwareSerial"** into the search bar.
+   - Locate the **EspSoftwareSerial** library in the search results.
+   - Click the **Install** button to add the library to your Arduino environment.
+
+2. **Install DRA818:**
+
+   > **Note:** The version of the DRA818 library available through the Arduino Library Manager is currently broken. To ensure proper functionality, you need to install it manually from the official GitHub release.
+
+   - **Download the DRA818 Library ZIP:**
+     - Visit the [DRA818 v1.0.1 Release Page](https://github.com/fatpat/arduino-dra818/releases/tag/v1.0.1).
+     - Click on the **"Source code (zip)"** link to download the ZIP file of the library.
+
+   - **Add the DRA818 Library to Arduino IDE:**
+     - Open the Arduino IDE.
+     - Go to `Sketch` > `Include Library` > `Add .ZIP Library...`.
+     - In the file dialog, navigate to the location where you downloaded the `arduino-dra818-1.0.1.zip` file.
+     - Select the ZIP file and click **Open**.
+     - A confirmation message should appear indicating that the library was added successfully.
+
+3. **Install AudioTools:**
+
+   - **Download the AudioTools Library ZIP:**
+     - Visit the [AudioTools v1.2.3 Release Page](https://github.com/pschatzmann/arduino-audio-tools/releases/tag/v1.2.3).
+     - Click on the **"Source code (zip)"** link to download the ZIP file of the library.
+
+   - **Add the AudioTools Library to Arduino IDE:**
+     - Open the Arduino IDE.
+     - Go to `Sketch` > `Include Library` > `Add .ZIP Library...`.
+     - In the file dialog, navigate to the location where you downloaded the `arduino-audiotools-1.2.3.zip` file.
+     - Select the ZIP file and click **Open**.
+     - A confirmation message should appear indicating that the library was added successfully.
+
+4. **Install adpcm:**
+
+   - **Download the adpcm Library ZIP:**
+     - Visit the [adpcm v1.2.1 Release Page](https://github.com/pschatzmann/adpcm/releases/tag/v1.2.1).
+     - Click on the **"Source code (zip)"** link to download the ZIP file of the library.
+
+   - **Add the adpcm Library to Arduino IDE:**
+     - Open the Arduino IDE.
+     - Go to `Sketch` > `Include Library` > `Add .ZIP Library...`.
+     - In the file dialog, navigate to the location where you downloaded the `codec-adpcm-1.2.1.zip` file.
+     - Select the ZIP file and click **Open**.
+     - A confirmation message should appear indicating that the library was added successfully.
+
+5. **Install esp32-afsk:**
+
+   - **Download the esp32-afsk Library ZIP:**
+     - Visit the [esp32-afsk v0.1.3 Release Page](https://github.com/dkaukov/esp32-afsk/releases/tag/v0.1.3).
+     - Click on the **"Source code (zip)"** link to download the ZIP file of the library.
+
+   - **Add the adpcm Library to Arduino IDE:**
+     - Open the Arduino IDE.
+     - Go to `Sketch` > `Include Library` > `Add .ZIP Library...`.
+     - In the file dialog, navigate to the location where you downloaded the `esp32-afk-0.1.3.zip` file.
+     - Select the ZIP file and click **Open**.
+     - A confirmation message should appear indicating that the library was added successfully.
+
+6. **Confirm All Libraries Are Installed:**
+
+   - After completing the above steps, go to `Sketch` > `Include Library` and scroll down to the bottom where you will find the section labeled `Contributed Libraries` (light gray). Ensure that **adpcm**, **audio-tools**,  **DRA818**, **esp32-afk** and **EspSoftwareSerial** are listed.
+   - If any libraries are missing, revisit the installation steps to ensure they were added correctly.
+
+### Opening the Project (Arduino IDE)
+
+1. **Open the Project:**
+   - Go to `File` > `Open`.
+   - Navigate and open: `kv4p-ht/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino`.
+
+### Building the Project (Arduino IDE)
+
+1. **Select the ESP32 Board:**
+   - Go to `Tools` > `Board` and select **"ESP32 Dev Module"**.
+
+2. **Select the Correct Port:**
+   - Connect your ESP32 to your computer via USB.
+   - Go to `Tools` > `Port` and select the appropriate COM port (Windows) or `/dev/tty.*` device (macOS/Linux).
+
+3. **Verify the Sketch:**
+   - Click the **Verify** button (checkmark) in the Arduino toolbar or press `Ctrl+R` (`Cmd+R` on macOS).
+   - The IDE will compile the sketch and display any errors or warnings in the output pane.
+   - Ensure that the sketch compiles without errors.
+
+### Uploading to the ESP32 (Arduino IDE)
+
+1. **Upload the Firmware:**
+   - Click the **Upload** button (right arrow) in the Arduino toolbar or press `Ctrl+U` (`Cmd+U` on macOS).
+   - The Arduino IDE will compile (if not already done) and upload the firmware to the ESP32.
+   - Monitor the output pane for upload progress and confirmation of success.
+
+## Additional Notes
 
 - **Consistent Project Structure:**
   - Ensure that any changes made in one environment (e.g., library installations, code modifications) are compatible with the other to maintain consistency across both build systems.


### PR DESCRIPTION
This PR updates the instructions for compiling the firmware:

1. Re-arranged the build options so PlatformIO is first, and marked as preferred. While Arduino IDE is generally a simpler IDE, for a project of this size I believe Arduino IDE is harder to use. The initial configuration of the options and library dependencies is very manual and surfaces a lot of details.
2. Moved the section comparing PlatformIO and Arduino IDE to the top. The user needs that info to make an educated choice about a build environment before delving into the build instructions.
3. Added a few clarifications to the PlatformIO instructions such as the alien head icon and a note on trusting the project.
4. Update the Arduino IDE instructions to include all the libraries that were missing and where to get each. I matched all the libs and versions in the `platformio.ini` file.

The esp32-afk git LFS problem in PlatformIO appears solved. 👍 

We could potentially remove some sections such as the one on renaming `.ino` to `.cpp` and the `Additional Notes` section. For now I left them in.

One other beginner note that may be useful is how to enable Debug Build and show the Serial Monitor so you can see firmware debug messages. Thoughts?