### PR TITLE
Implement software RX CTCSS detection and tune soft squelch

### DIFF
--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/dsp/audioResampler.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/dsp/audioResampler.h
@@ -115,10 +115,12 @@ public:
   bool begin() {
     captureSamples = 0;
     hasPendingByte = false;
-    return decimator.begin();
+    return decimator.begin(highStop, lowStop);
   }
 
-  bool setFilters(bool highStop, bool lowStop) {
+  bool setFilters(bool useHighStop, bool useLowStop) {
+    highStop = useHighStop;
+    lowStop = useLowStop;
     return decimator.begin(highStop, lowStop);
   }
 
@@ -149,6 +151,8 @@ private:
   size_t captureSamples = 0;
   uint8_t pendingByte = 0;
   bool hasPendingByte = false;
+  bool highStop = false;
+  bool lowStop = false;
 
   size_t decimateFrame(uint8_t *dst) {
     int16_t *pcmWire = (int16_t *)dst;

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/dsp/audioResampler.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/dsp/audioResampler.h
@@ -32,9 +32,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 static constexpr int16_t AUDIO_DECIMATOR_TAPS = 65;
 static constexpr int16_t AUDIO_DECIMATOR_STATE_LEN = AUDIO_DECIMATOR_TAPS + 4;
 static constexpr float AUDIO_DECIMATOR_CUTOFF_HZ = 6800.0f;
+static constexpr float AUDIO_FILTER_LOW_STOP_CUTOFF_HZ = 300.0f;
+static constexpr float AUDIO_FILTER_HIGH_STOP_CUTOFF_HZ = 3000.0f;
 
-inline void audioDesignDecimatorCoeffs(float *coeffs) {
-  afsk::dsp::afsk_design_lowpass_hamming(coeffs, AUDIO_DECIMATOR_TAPS, AUDIO_DECIMATOR_CUTOFF_HZ, AUDIO_SAMPLE_RATE);
+inline void audioDesignDecimatorCoeffs(float *coeffs, bool highStop = false, bool lowStop = false) {
+  float lowPassCoeffs[AUDIO_DECIMATOR_TAPS];
+  float cutoff = highStop ? AUDIO_FILTER_HIGH_STOP_CUTOFF_HZ : AUDIO_DECIMATOR_CUTOFF_HZ;
+  afsk::dsp::afsk_design_lowpass_hamming(coeffs, AUDIO_DECIMATOR_TAPS, cutoff, AUDIO_SAMPLE_RATE);
+  if (lowStop) {
+    afsk::dsp::afsk_design_lowpass_hamming(lowPassCoeffs, AUDIO_DECIMATOR_TAPS,
+                                           AUDIO_FILTER_LOW_STOP_CUTOFF_HZ, AUDIO_SAMPLE_RATE);
+    for (size_t i = 0; i < AUDIO_DECIMATOR_TAPS; i++) {
+      coeffs[i] -= lowPassCoeffs[i];
+    }
+  }
 }
 
 inline size_t upsampleWireTo48kLinear(const int16_t *input, size_t inputSamples, int16_t *output, size_t outputCapacity) {
@@ -54,8 +65,9 @@ inline size_t upsampleWireTo48kLinear(const int16_t *input, size_t inputSamples,
 
 class AudioFirDecimator {
 public:
-  bool begin() {
-    audioDesignDecimatorCoeffs(coeffs);
+  bool begin(bool highStop = false, bool lowStop = false) {
+    audioDesignDecimatorCoeffs(coeffs, highStop, lowStop);
+    memset(delay, 0, sizeof(delay));
     fir.initDecim(coeffs, AUDIO_DECIMATOR_TAPS, coeffs, delay, AUDIO_DECIMATOR_STATE_LEN, AUDIO_RESAMPLE_RATIO);
     return fir.len == AUDIO_DECIMATOR_TAPS;
   }
@@ -104,6 +116,10 @@ public:
     captureSamples = 0;
     hasPendingByte = false;
     return decimator.begin();
+  }
+
+  bool setFilters(bool highStop, bool lowStop) {
+    return decimator.begin(highStop, lowStop);
   }
 
   size_t convert(uint8_t *src, size_t size) override {

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/dsp/ctcssDetector.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/dsp/ctcssDetector.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <math.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <AfskDemodulator.h>
+
+class CtcssDetector {
+public:
+  explicit CtcssDetector(uint32_t sampleRate) : sampleRate(sampleRate) {
+    setToneIndex(0);
+  }
+
+  void setToneIndex(uint8_t index) {
+    toneIndex = index <= TONE_COUNT ? index : 0;
+    targetHz = toneIndex == 0 ? 0.0f : toneFrequency(toneIndex);
+    reset();
+  }
+
+  uint8_t getToneIndex() const { return toneIndex; }
+  float getTargetHz() const { return targetHz; }
+  bool isDetected() const { return toneIndex == 0 || detected; }
+
+  void reset() {
+    sampleCount = 0;
+    signalEnergy = 0.0;
+    targetReal = 0.0;
+    targetImag = 0.0;
+    oscillator.init(sampleRate == 0 ? 1.0f : (float)sampleRate, targetHz);
+    detected = toneIndex == 0;
+  }
+
+  void process(int16_t sample) {
+    if (toneIndex == 0 || sampleRate == 0) {
+      return;
+    }
+
+    float x = (float)sample / 32768.0f;
+    targetReal += x * oscillator.cos();
+    targetImag -= x * oscillator.sin();
+    signalEnergy += x * x;
+    oscillator.next();
+
+    sampleCount++;
+    if (sampleCount >= detectionWindowSamples()) {
+      float toneEnergy = (targetReal * targetReal) + (targetImag * targetImag);
+      float normalized = signalEnergy > 0.0f ? (2.0f * toneEnergy) / ((float)sampleCount * signalEnergy) : 0.0f;
+      detected = signalEnergy >= MINIMUM_WINDOW_ENERGY && normalized >= MINIMUM_TONE_ENERGY_RATIO;
+      sampleCount = 0;
+      signalEnergy = 0.0;
+      targetReal = 0.0;
+      targetImag = 0.0;
+      oscillator.init((float)sampleRate, targetHz);
+    }
+  }
+
+  static float toneFrequency(uint8_t index) {
+    static const float frequencies[TONE_COUNT] = {
+      67.0f, 71.9f, 74.4f, 77.0f, 79.7f, 82.5f, 85.4f, 88.5f, 91.5f, 94.8f,
+      97.4f, 100.0f, 103.5f, 107.2f, 110.9f, 114.8f, 118.8f, 123.0f, 127.3f, 131.8f,
+      136.5f, 141.3f, 146.2f, 151.4f, 156.7f, 162.2f, 167.9f, 173.8f, 179.9f, 186.2f,
+      192.8f, 203.5f, 210.7f, 218.1f, 225.7f, 233.6f, 241.8f, 250.3f
+    };
+    return index >= 1 && index <= TONE_COUNT ? frequencies[index - 1] : 0.0f;
+  }
+
+private:
+  static constexpr uint8_t TONE_COUNT = 38;
+  static constexpr float DETECTION_WINDOW_SECONDS = 0.4f;
+  static constexpr float MINIMUM_WINDOW_ENERGY = 0.01f;
+  static constexpr float MINIMUM_TONE_ENERGY_RATIO = 0.35f;
+
+  uint32_t sampleRate;
+  uint8_t toneIndex = 0;
+  float targetHz = 0.0f;
+  afsk::dsp::DdsOsc oscillator;
+  uint32_t sampleCount = 0;
+  float signalEnergy = 0.0f;
+  float targetReal = 0.0f;
+  float targetImag = 0.0f;
+  bool detected = true;
+
+  uint32_t detectionWindowSamples() const {
+    uint32_t samples = (uint32_t)((float)sampleRate * DETECTION_WINDOW_SECONDS);
+    return samples == 0 ? 1 : samples;
+  }
+};

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/dsp/softSquelchEffect.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/dsp/softSquelchEffect.h
@@ -121,10 +121,10 @@ public:
   }
 
 private:
-  static constexpr float SOFT_SQUELCH_LOW_HZ = 200.0f;
-  static constexpr float SOFT_SQUELCH_HIGH_HZ = 500.0f;
-  static constexpr float SOFT_SQUELCH_THRESHOLD_ZCR = 30.0f;
-  static constexpr int SOFT_SQUELCH_BPF_TAPS = 33;
+  static constexpr float SOFT_SQUELCH_LOW_HZ = 3500.0f;
+  static constexpr float SOFT_SQUELCH_HIGH_HZ = 4000.0f;
+  static constexpr float SOFT_SQUELCH_THRESHOLD_ZCR = 350.0f;
+  static constexpr int SOFT_SQUELCH_BPF_TAPS = 65;
   static constexpr int SOFT_SQUELCH_BPF_STATE_LEN = SOFT_SQUELCH_BPF_TAPS + 4;
 
   uint32_t sampleRate;
@@ -141,13 +141,13 @@ private:
   bool hardwareSquelched = false;
   CtcssDetector ctcssDetector;
   uint8_t deadbandLevel = 0;
-  float deadband = 0.45f;
+  float deadband = 0.13f;
 
   static float deadbandForLevel(uint8_t level) {
     if (level > 8) {
       level = 8;
     }
-    return 0.45f - ((float)level / 8.0f) * (0.45f - 0.08f);
+    return 0.13f - ((float)level / 8.0f) * (0.13f - 0.08f);
   }
 
   bool isBypassed() const {

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/dsp/softSquelchEffect.h
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/dsp/softSquelchEffect.h
@@ -23,6 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <math.h>
 #include <string.h>
 #include "../globals.h"
+#include "ctcssDetector.h"
 
 #define ZCR_DECAY_TIME 0.100f  // seconds
 #define SQ_CLOSE_DELAY 0.250f  // seconds
@@ -32,7 +33,8 @@ public:
   SoftSquelchEffect(uint32_t sampleRate = AUDIO_SAMPLE_RATE, float zcrTauSec = ZCR_DECAY_TIME, float closeDelaySec = SQ_CLOSE_DELAY)
     : sampleRate(sampleRate == 0 ? AUDIO_SAMPLE_RATE : sampleRate),
       zcrTauSec(zcrTauSec),
-      closeDelaySec(closeDelaySec) {
+      closeDelaySec(closeDelaySec),
+      ctcssDetector(this->sampleRate) {
     zcrAlpha = 1.0f - expf(-1.0f / ((float)this->sampleRate * this->zcrTauSec));
     initBpf();
     resetState();
@@ -50,6 +52,7 @@ public:
     previousOutsideSample = 0.0f;
     iirZcr = resetClosedZcr();
     aboveThresholdSamples = closeDelaySamples();
+    ctcssDetector.reset();
     setSoftSqOpen(false);
   }
 
@@ -57,8 +60,17 @@ public:
     hardwareSquelched = squelched;
   }
 
+  void setCtcssTone(uint8_t toneIndex) {
+    ctcssDetector.setToneIndex(toneIndex);
+  }
+
   effect_t process(effect_t input) override {
-    if (!active() || hardwareSquelched) {
+    if (!active()) {
+      return input;
+    }
+
+    ctcssDetector.process(input);
+    if (hardwareSquelched) {
       return input;
     }
 
@@ -82,6 +94,9 @@ public:
   }
 
   bool isSoftOpen() const {
+    if (!ctcssDetector.isDetected()) {
+      return false;
+    }
     if (isBypassed()) {
       return true;
     }
@@ -124,6 +139,7 @@ private:
   uint32_t aboveThresholdSamples = 0;
   bool softSqOpen = false;
   bool hardwareSquelched = false;
+  CtcssDetector ctcssDetector;
   uint8_t deadbandLevel = 0;
   float deadband = 0.45f;
 

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
@@ -319,7 +319,7 @@ void reconcileDesiredState(bool sendReport = true) {
 
   if ((desiredState.flags & HOST_STATE_RADIO_CONFIG_VALID) && radioConfigChanged()) {
     drainRadioSerial();
-    while (!sa818.group(desiredState.bw, desiredState.freq_tx, desiredState.freq_rx, desiredState.ctcss_tx, 0, desiredState.ctcss_rx)) {
+    while (!sa818.group(desiredState.bw, desiredState.freq_tx, desiredState.freq_rx, desiredState.ctcss_tx, 0, 0)) {
       lastDeviceStateError = DEVICE_STATE_ERROR_RADIO_CONFIG_FAILED;
       esp_task_wdt_reset();
     }
@@ -329,6 +329,7 @@ void reconcileDesiredState(bool sendReport = true) {
     appliedState.ctcss_tx = desiredState.ctcss_tx;
     appliedState.squelch = desiredState.squelch;
     softSquelchEffect.setDeadbandLevel(appliedState.squelch);
+    softSquelchEffect.setCtcssTone(desiredState.ctcss_rx);
     appliedState.ctcss_rx = desiredState.ctcss_rx;
     appliedState.memoryId = desiredState.memoryId;
     appliedState.flags |= HOST_STATE_RADIO_CONFIG_VALID;

--- a/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
+++ b/microcontroller-src/kv4p_ht_esp32_wroom_32/kv4p_ht_esp32_wroom_32.ino
@@ -307,10 +307,12 @@ void reconcileDesiredState(bool sendReport = true) {
   uint16_t appliedFilterFlags = appliedState.flags & (HOST_STATE_FILTER_PRE | HOST_STATE_FILTER_HIGH | HOST_STATE_FILTER_LOW);
   if (!filtersApplied || filterFlags != appliedFilterFlags) {
     drainRadioSerial();
-    while (!sa818.filters((filterFlags & HOST_STATE_FILTER_PRE), (filterFlags & HOST_STATE_FILTER_HIGH), (filterFlags & HOST_STATE_FILTER_LOW))) {
+    while (!sa818.filters((filterFlags & HOST_STATE_FILTER_PRE), false, false)) {
       lastDeviceStateError = DEVICE_STATE_ERROR_FILTERS_FAILED;
       esp_task_wdt_reset();
     }
+    rxDownsample.setFilters((filterFlags & HOST_STATE_FILTER_HIGH) != 0,
+                            (filterFlags & HOST_STATE_FILTER_LOW) != 0);
     appliedState.flags = (appliedState.flags & ~(HOST_STATE_FILTER_PRE | HOST_STATE_FILTER_HIGH | HOST_STATE_FILTER_LOW)) | filterFlags;
     filtersApplied = true;
   }

--- a/microcontroller-src/test/test_audio_codec/test_audio_codec.cpp
+++ b/microcontroller-src/test/test_audio_codec/test_audio_codec.cpp
@@ -63,6 +63,16 @@ void test_decimator_coefficients_have_expected_dc_gain() {
   TEST_ASSERT_FLOAT_WITHIN(0.0001f, kExpectedDecimatorDcGain, sum);
 }
 
+void test_low_stop_decimator_coefficients_reject_dc() {
+  float coeffs[AUDIO_DECIMATOR_TAPS];
+  float sum = 0.0f;
+  audioDesignDecimatorCoeffs(coeffs, false, true);
+  for (size_t i = 0; i < AUDIO_DECIMATOR_TAPS; i++) {
+    sum += coeffs[i];
+  }
+  TEST_ASSERT_FLOAT_WITHIN(0.0001f, 0.0f, sum);
+}
+
 void test_decimator_expected_gain_for_dc_after_warmup() {
   static constexpr int16_t kInputLevel = 10000;
   static constexpr int16_t kExpectedLevel = (int16_t)(kInputLevel * kExpectedDecimatorDcGain);
@@ -89,6 +99,7 @@ void setup() {
   RUN_TEST(test_upsampler_interpolates);
   RUN_TEST(test_decimator_output_length);
   RUN_TEST(test_decimator_coefficients_have_expected_dc_gain);
+  RUN_TEST(test_low_stop_decimator_coefficients_reject_dc);
   RUN_TEST(test_decimator_expected_gain_for_dc_after_warmup);
   UNITY_END();
 }

--- a/microcontroller-src/test/test_audio_codec/test_audio_codec.cpp
+++ b/microcontroller-src/test/test_audio_codec/test_audio_codec.cpp
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <unity.h>
 
 #include "dsp/audioResampler.h"
+#include "dsp/ctcssDetector.h"
 
 static_assert(AUDIO_FRAME_SAMPLES_WIRE == 249, "128-byte mono IMA ADPCM block must decode to 249 samples");
 static_assert(AUDIO_FRAME_SAMPLES_48K == 747, "249 samples at 16 kHz must map to 747 samples at 48 kHz");
@@ -93,6 +94,29 @@ void test_decimator_expected_gain_for_dc_after_warmup() {
   TEST_ASSERT_INT16_WITHIN(2, kExpectedLevel, out[AUDIO_FRAME_SAMPLES_WIRE - 1]);
 }
 
+void feed_detector_tone(CtcssDetector &detector, float frequencyHz, float seconds) {
+  static constexpr float kPi = 3.14159265358979323846f;
+  size_t samples = (size_t)(AUDIO_SAMPLE_RATE * seconds);
+  for (size_t i = 0; i < samples; i++) {
+    int16_t sample = (int16_t)(8000.0f * sinf(2.0f * kPi * frequencyHz * (float)i / AUDIO_SAMPLE_RATE));
+    detector.process(sample);
+  }
+}
+
+void test_ctcss_detector_recognizes_selected_tone() {
+  CtcssDetector detector(AUDIO_SAMPLE_RATE);
+  detector.setToneIndex(12);
+  feed_detector_tone(detector, 100.0f, 0.4f);
+  TEST_ASSERT_TRUE(detector.isDetected());
+}
+
+void test_ctcss_detector_rejects_adjacent_tone() {
+  CtcssDetector detector(AUDIO_SAMPLE_RATE);
+  detector.setToneIndex(12);
+  feed_detector_tone(detector, 103.5f, 0.4f);
+  TEST_ASSERT_FALSE(detector.isDetected());
+}
+
 void setup() {
   UNITY_BEGIN();
   RUN_TEST(test_upsampler_output_length);
@@ -101,6 +125,8 @@ void setup() {
   RUN_TEST(test_decimator_coefficients_have_expected_dc_gain);
   RUN_TEST(test_low_stop_decimator_coefficients_reject_dc);
   RUN_TEST(test_decimator_expected_gain_for_dc_after_warmup);
+  RUN_TEST(test_ctcss_detector_recognizes_selected_tone);
+  RUN_TEST(test_ctcss_detector_rejects_adjacent_tone);
   UNITY_END();
 }
 


### PR DESCRIPTION
## Summary

This PR moves RX CTCSS detection from the SA818 module into the firmware DSP pipeline.

The SA818 is now configured with RX CTCSS disabled, while TX CTCSS remains module-controlled. Received audio is analyzed in firmware and gated by `SoftSquelchEffect` when the configured CTCSS tone is detected.

## Changes

- Add DSP detection for all 38 SA818 CTCSS tones.
- Preserve tone index `0` as CTCSS disabled/bypassed.
- Use the table-based `afsk::dsp::DdsOsc` for efficient sine/cosine correlation.
- Analyze audio over a 400 ms window to distinguish adjacent CTCSS tones.
- Combine CTCSS detection with the existing soft-squelch decision.
- Configure the SA818 with RX CTCSS disabled.
- Keep TX CTCSS behavior unchanged.
- Move soft-squelch noise analysis to the 3.5–4.0 kHz portion of the baseband, away from CTCSS and most voice energy.
- Tune the soft-squelch FIR, ZCR threshold, and sensitivity scale for the new analysis band.


Fixes: https://github.com/VanceVagell/kv4p-ht/issues/444
